### PR TITLE
pcwconfig: before fallback to default lookup in feature section

### DIFF
--- a/webui/settings.py
+++ b/webui/settings.py
@@ -247,7 +247,7 @@ class PCWConfig():
     @staticmethod
     def get_providers_for(feature: str, namespace: str):
         return ConfigFile().getList('{}.namespace.{}/providers'.format(feature, namespace),
-                                    ['ec2', 'azure', 'gce'])
+                                    ConfigFile().getList('{}/providers'.format(feature), ['ec2', 'azure', 'gce']))
 
     @staticmethod
     def has(setting: str) -> bool:


### PR DESCRIPTION
This was overlooked during refactoring.
Initial idea was to have such order :
1. <feature>.namespace.<namespace>/providers
2. <feature>/providers
3. [ec2,gce,azure]
Due to mistake second option was not included
in original refactoring PR. This tiny patch
fixing that.