### PR TITLE
Email notification: Display openqa job url in email notification

### DIFF
--- a/ocw/lib/emailnotify.py
+++ b/ocw/lib/emailnotify.py
@@ -17,18 +17,20 @@ def draw_instance_table(objects):
     from ocw import views
     table = Texttable(max_width=0)
     table.set_deco(Texttable.HEADER)
-    table.header(['Provider', 'id', 'Created-By', 'Namespace', 'Age', 'Delete'])
+    table.header(['Provider', 'id', 'Created-By', 'Namespace', 'Age', 'Delete', 'openQA'])
     for i in objects:
         j = json.loads(i.csp_info)
         hours, remainder = divmod(i.age.total_seconds(), 3600)
         minutes, seconds = divmod(remainder, 60)
+        link = i.get_openqa_job_link()
         table.add_row([
             i.provider,
             i.instance_id,
             j['tags']['openqa_created_by'],
             i.vault_namespace,
             i.age_formated(),
-            build_absolute_uri(reverse(views.delete, args=[i.id]))
+            build_absolute_uri(reverse(views.delete, args=[i.id])),
+            "" if link is None else link['url']
         ])
     return table.draw()
 

--- a/ocw/models.py
+++ b/ocw/models.py
@@ -1,6 +1,7 @@
 from django.db import models
 from enum import Enum
 from datetime import timedelta
+from webui.settings import PCWConfig
 import json
 
 
@@ -72,6 +73,14 @@ class Instance(models.Model):
         except json.JSONDecodeError:
             pass
         return dict()
+
+    def get_openqa_job_link(self):
+        tags = self.tags()
+        if tags.get('openqa_created_by', '') == 'openqa-suse-de' and 'openqa_var_JOB_ID' in tags:
+            url = '{}/t{}'.format(PCWConfig.get_feature_property('webui', 'openqa_url'), tags['openqa_var_JOB_ID'])
+            title = tags.get('openqa_var_NAME', '')
+            return {'url': url, 'title': title}
+        return None
 
     class Meta:
         unique_together = (('provider', 'instance_id'),)

--- a/ocw/tables.py
+++ b/ocw/tables.py
@@ -7,7 +7,6 @@ from .models import StateChoice
 from django_tables2.utils import A
 from django.utils.html import format_html
 from django.templatetags.static import static
-from webui.settings import PCWConfig
 from django.template.loader import get_template
 
 
@@ -25,12 +24,10 @@ class OpenQALinkColumn(tables.Column):
         return ""
 
     def render(self, record):
-        tags = record.tags()
-        if tags.get('openqa_created_by', '') == 'openqa-suse-de' and 'openqa_var_JOB_ID' in tags:
-            link = '{}/t{}'.format(PCWConfig.get_feature_property('webui', 'openqa_url'), tags['openqa_var_JOB_ID'])
-            alt = tags.get('openqa_var_NAME', '')
+        link = record.get_openqa_job_link()
+        if link is not None:
             return format_html('<a href="{}" "><img alt="{}" title="{}" src="{}"/></a>',
-                               link, alt, alt, static('img/openqa.svg'))
+                               link['url'], link['title'], link['title'], static('img/openqa.svg'))
         return ""
 
 

--- a/tests/generators.py
+++ b/tests/generators.py
@@ -42,9 +42,12 @@ class ec2_image_mock:
         self.meta = ec2_meta_mock()
         self.name = fake.uuid4()
 
+def ec2_tags_mock(tags={fake.uuid4(): fake.uuid4()}):
+    return [ {'Key': key, 'Value': tags[key]} for key in tags]
+
 
 class ec2_instance_mock:
-    def __init__(self):
+    def __init__(self, **kwargs):
         self.state = {'Name': fake.uuid4()}
         self.instance_id = fake.uuid4()
         self.image_id = fake.uuid4()
@@ -55,7 +58,7 @@ class ec2_instance_mock:
         self.public_ip_address = fake.uuid4()
         self.security_groups = [{'GroupName': fake.uuid4()}, {'GroupName': fake.uuid4()}]
         self.sriov_net_support = fake.uuid4()
-        self.tags = [{'Key': fake.uuid4(), 'Value': fake.uuid4()}]
+        self.tags = ec2_tags_mock(**kwargs)
         self.state_reason = {'Message': fake.uuid4()}
         self.image = ec2_image_mock()
 

--- a/tests/test_emailnotify.py
+++ b/tests/test_emailnotify.py
@@ -1,0 +1,26 @@
+from ocw.lib.emailnotify import draw_instance_table
+from ocw.lib.db import ec2_to_local_instance
+from ocw.models import Instance
+from tests.generators import ec2_instance_mock
+
+
+def test_draw_instance_table():
+    objects = [
+            ec2_to_local_instance(ec2_instance_mock(tags=
+                {
+                    'openqa_var_JOB_ID': 123,
+                    'openqa_created_by': 'openqa-suse-de'
+                }), 'ns', 'moon-west'),
+                ec2_to_local_instance(ec2_instance_mock(tags=
+                {
+                    'openqa_var_JOB_ID': 666,
+                    'openqa_created_by': 'i-dont-have-a-link'
+                }), 'ns', 'moon-west')
+            ]
+    s = draw_instance_table(objects)
+
+    assert 'https://openqa.suse.de/t123' in s
+    assert 'https://openqa.suse.de/t666' not in s
+
+    for instance_id in [o.instance_id for o in objects]:
+        assert instance_id in s


### PR DESCRIPTION
The email would look like this:
```
Provider           id              Created-By     Namespace    Age              Delete                          openQA             
===================================================================================================================================
EC2        i-03d912e0eabd0ce34   openqa-suse-de   qac         6h10m   https://127.0.0.1/delete/84   https://openqa.suse.de/t7127196
```