### PR TITLE
Add /health.json and /instances.json

### DIFF
--- a/ocw/urls.py
+++ b/ocw/urls.py
@@ -3,7 +3,9 @@ from . import views
 
 urlpatterns = [
     path('', views.FilteredInstanceTableView.as_view(), name='instances'),
+    path('health.json', views.health, name='health'),
     path('instances', views.FilteredInstanceTableView.as_view(), name='instances'),
+    path('instances.json', views.instance_json, name='instances_json'),
     path('update', views.update, name='update'),
     path('update/status', views.update_status, name='update_status'),
     path('delete/<str:key_id>', views.delete, name='delete_instance'),

--- a/ocw/views.py
+++ b/ocw/views.py
@@ -5,7 +5,8 @@ from .models import Instance
 from .tables import InstanceTable
 from .tables import InstanceFilter
 from django.contrib.auth.decorators import login_required
-from django.http import JsonResponse
+from django.http import JsonResponse, HttpResponse
+from django.core.serializers import serialize
 
 
 class FilteredSingleTableView(SingleTableView):
@@ -27,6 +28,31 @@ class FilteredInstanceTableView(FilteredSingleTableView):
     model = Instance
     table_class = InstanceTable
     filter_class = InstanceFilter
+
+
+def health(request):
+    return JsonResponse({"status": "ok"})
+
+
+def instance_json(request):
+    instances = Instance.objects.all()
+    data = serialize(
+        "json",
+        instances,
+        fields=(
+            "provider",
+            "state",
+            "first_seen",
+            "last_seen",
+            "age",
+            "ttl",
+            "instance_id",
+            "region",
+            "vault_namespace",
+            "csp_info",
+        ),
+    )
+    return HttpResponse(data, content_type="application/json")
 
 
 def update(request):


### PR DESCRIPTION
Add `/instances.json` path to query all currently known instances as json object and `/health.json` to query the health of the instance. Both are required for CLI tools to query the instance without using the WebUI.

This PR addresses https://github.com/SUSE/pcw/issues/124