### PR TITLE
Limit instances.json to active instances only

### DIFF
--- a/ocw/views.py
+++ b/ocw/views.py
@@ -35,7 +35,7 @@ def health(request):
 
 
 def instance_json(request):
-    instances = Instance.objects.all()
+    instances = Instance.objects.filter(active=True)
     data = serialize(
         "json",
         instances,


### PR DESCRIPTION
The answer of /instances.json is too verbose as it prints all ever
existing instances. This commit updates the response to only list active
instances.

Follow-up to https://github.com/SUSE/pcw/pull/131
Related issue: https://github.com/SUSE/pcw/issues/124