### PR TITLE
Fix collision of static files

### DIFF
--- a/container-startup
+++ b/container-startup
@@ -36,7 +36,6 @@ case "$CMD" in
 		;;
 	"run")
 		python3 manage.py migrate
-		python3 manage.py collectstatic
 		uwsgi --enable-threads --http 0.0.0.0:8000 --module webui.wsgi --static-map /static=/pcw/ocw/static
 		;;
 	"migrate")


### PR DESCRIPTION
Fix a unwanted collision of static files in the startup-script caused by
running `collectstatic` every time.

Fixes https://github.com/SUSE/pcw/issues/134