### PR TITLE
Remove SUSE CA and switch to http-sockets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,14 +9,13 @@ COPY . /pcw/
 
 # We do the whole installation and configuration in one layer:
 # * Install system requirements
-RUN zypper -n ar http://download.suse.de/ibs/SUSE:/CA/openSUSE_Leap_15.3/ SUSE_CA && \
-    zypper -n in ca-certificates-suse python3 python3-devel python3-pip gcc && rm -rf /var/cache
-# Install pip requirements
-RUN pip install -r /pcw/requirements.txt && rm -rf /var/cache
+# * Install pip requirements
+# * Empty system cache to conserve some space
+RUN zypper -n in python3 python3-devel python3-pip gcc && pip install -r /pcw/requirements.txt && rm -rf /var/cache
 
 ## Finalize ################################################################# ##
 
-VOLUME /etc/pcw.ini
+VOLUME /pcw
 VOLUME /pcw/db
 
 EXPOSE 8000/tcp

--- a/container-startup
+++ b/container-startup
@@ -36,7 +36,7 @@ case "$CMD" in
 		;;
 	"run")
 		python3 manage.py migrate
-		uwsgi --enable-threads --http 0.0.0.0:8000 --module webui.wsgi --static-map /static=/pcw/ocw/static
+		uwsgi --enable-threads --http-socket 0.0.0.0:8000 --module webui.wsgi --static-map /static=/pcw/ocw/static
 		;;
 	"migrate")
 		python3 manage.py migrate


### PR DESCRIPTION
This commit improves the container deployment by switching the `uwsgi`
parameter to http-socket for usage in Tumbleweed containers and by
removing the unnecessary SUSE CA certificate installation. The later
won't be required in future scenarios without vault so it can be removed
from the generic Containerfile