### PR TITLE
Remove /pcw VOLUME and add python3 module to uwsgi

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,10 @@ COPY . /pcw/
 # * Install system requirements
 # * Install pip requirements
 # * Empty system cache to conserve some space
-RUN zypper -n in python3 python3-devel python3-pip gcc && pip install -r /pcw/requirements.txt && rm -rf /var/cache
+RUN zypper -n in python3 python3-devel python3-pip gcc && pip3 install -r /pcw/requirements.txt && rm -rf /var/cache
 
 ## Finalize ################################################################# ##
 
-VOLUME /pcw
 VOLUME /pcw/db
 
 EXPOSE 8000/tcp

--- a/container-startup
+++ b/container-startup
@@ -36,7 +36,7 @@ case "$CMD" in
 		;;
 	"run")
 		python3 manage.py migrate
-		uwsgi --enable-threads --http-socket 0.0.0.0:8000 --module webui.wsgi --static-map /static=/pcw/ocw/static
+		uwsgi --enable-threads --http-socket 0.0.0.0:8000  --plugins python3 --module webui.wsgi --static-map /static=/pcw/ocw/static
 		;;
 	"migrate")
 		python3 manage.py migrate


### PR DESCRIPTION
The /pcw VOLUME is unnecessary and can be removed. Also adds the python3
module to uwsgi to make it work on the Tumbleweed container.