### PR TITLE
Add container link to OBS project

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 PublicCloud-Watcher or `pcw` is a web app which monitors, displays and deletes resources on various Cloud Service Providers (CSPs). It identifies abandoned instances by searching for certain tags and performs cleanup tasks. It also deletes old custom uploaded images. The behavior differs per CSP.
 
+The fastest way to run PublicCloud-Watcher is via the provided containers, as described in the [Running a container](#running-a-container) section.
+
 ## Install
 
 See the [requirements.txt](requirements.txt). It's recommended to setup `pcw` in a virtual environment to avoid package collisions:
@@ -53,11 +55,20 @@ To build a docker/podman container with the default `suse/qac/pcw` tag, run
 
 This repository contains the skeleton `Dockerfile` for building a Publiccloud-Watcher docker/podman container.
 
-The resulting container requires the `/data` volume to be mounted which shall contain the `pcw.ini` file. Therein the database will also be stored in `/data/db`.
+## Running a container
 
-The container expects the `/etc/pcw.ini` file and the `/pcw/db` directory to be mounted. To create a container using e.g. the data directory `/srv/pcw` for both volumes and expose port 8000, run the following:
+You can use the already build containers from the [QAC project on build.opensuse.org](https://build.opensuse.org/package/show/devel:openSUSE:QA:QAC:containers/pcw):
 
-    podman create --hostname pcw --name pcw -v /srv/pcw/pcw.ini:/etc/pcw.ini -v /srv/pcw/db:/pcw/db -p 8000:8000/tcp suse/qac/pcw
+    podman pull registry.opensuse.org/devel/opensuse/qa/qac/containers/tumbleweed/qac/pcw:latest
+
+The PublicCloud-Watcher container requires two volumes to be mounted:
+
+* `/pcw/db` - volume where the database file is stored
+* `/etc/pcw.ini` - configuration ini file
+
+To create a container using e.g. the data directory `/srv/pcw` for both volumes and expose port 8000, run the following:
+
+    podman create --hostname pcw --name pcw -v /srv/pcw/pcw.ini:/etc/pcw.ini -v /srv/pcw/db:/pcw/db -p 8000:8000/tcp registry.opensuse.org/devel/opensuse/qa/qac/containers/tumbleweed/qac/pcw:latest
     podman start pcw
 
 For usage in docker simply replace `podman` by `docker` in the above command.
@@ -66,11 +77,11 @@ The `pcw` container runs by default the `/pcw/container-startup` startup helper 
 
     podman exec pcw /pcw/container-startup help
     
-    podman run -ti --rm --hostname pcw --name pcw -v /srv/pcw/pcw.ini:/etc/pcw.ini -v /srv/pcw/db:/pcw/db -p 8000:8000/tcp suse/qac/pcw /pcw/container-startup help
+    podman run -ti --rm --hostname pcw --name pcw -v /srv/pcw/pcw.ini:/etc/pcw.ini -v /srv/pcw/db:/pcw/db -p 8000:8000/tcp registry.opensuse.org/devel/opensuse/qa/qac/containers/tumbleweed/qac/pcw:latest /pcw/container-startup help
 
 To create the admin superuser within the created container named `pcw`, run
 
-    podman run -ti --rm -v /srv/pcw/pcw.ini:/etc/pcw.ini -v /srv/pcw/db:/pcw/db -p 8000:8000/tcp suse/qac/pcw /pcw/container-startup createsuperuser --email admin@example.com --username admin
+    podman run -ti --rm -v /srv/pcw/pcw.ini:/etc/pcw.ini -v /srv/pcw/db:/pcw/db -p 8000:8000/tcp registry.opensuse.org/devel/opensuse/qa/qac/containers/tumbleweed/qac/pcw:latest /pcw/container-startup createsuperuser --email admin@example.com --username admin
 
 ## Codecov
 


### PR DESCRIPTION
A `pcw` container is now being build in the QAC project. This commit
updates the README to point to the container in the openSUSE registry
and the setup instructions are also updated accordingly.