### PR TITLE
Remove deprecated python 3.6 from test runs

### DIFF
--- a/.github/workflows/pcw.yml
+++ b/.github/workflows/pcw.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.8]
+        python-version: [3.8]
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python


### PR DESCRIPTION
Python 3.6 is deprecated and the test runs are failing for the
Cryptographic libraries. Therefore it does not make sense to run those
tests anymore because they will always fail.

Solves https://github.com/SUSE/pcw/issues/144