### PR TITLE
Update Github link to SUSE

### DIFF
--- a/ocw/templates/base.html
+++ b/ocw/templates/base.html
@@ -14,9 +14,9 @@
             <div class="col-sm-6">
               <div class="logo">
                 <h1>OpenQA-CloudWatch</h1>
-                <a class="github-button" href="https://github.com/cfconrad/pcw/subscription"aria-label="Watch cfconrad/pcw on GitHub">Watch</a>
-                <a class="github-button" href="https://github.com/cfconrad/pcw/fork" data-icon="octicon-repo-forked" aria-label="Fork cfconrad/pcw on GitHub" >Fork</a>
-                <a class="github-button" href="https://github.com/cfconrad/pcw/issues" data-icon="octicon-issue-opened" data-show-count="true" aria-label="Issue cfconrad/pcw on GitHub">Issue</a>
+                <a class="github-button" href="https://github.com/SUSE/pcw/subscription"aria-label="Watch SUSE/pcw on GitHub">Watch</a>
+                <a class="github-button" href="https://github.com/SUSE/pcw/fork" data-icon="octicon-repo-forked" aria-label="Fork SUSE/pcw on GitHub" >Fork</a>
+                <a class="github-button" href="https://github.com/SUSE/pcw/issues" data-icon="octicon-issue-opened" data-show-count="true" aria-label="Issue SUSE/pcw on GitHub">Issue</a>
               </div>
             </div>
             <div class="col-sm-6">


### PR DESCRIPTION
Update the GitHub links to the SUSE project instead of linking to cfconrad's home project.