### PR TITLE
Add dependabot to check Python a GitHub Actions dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+---
+version: 2
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+updates:
+  # Update Python requirements
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      day: "monday"
+      time: "6:00"
+      timezone: "Europe/Prague"
+  # Update GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "6:00"
+      timezone: "Europe/Prague"


### PR DESCRIPTION
The [Dependabot](https://docs.github.com/en/code-security/dependabot) is checking our Python modules and GitHub Actions and their dependencies. It creates pull request whenever there is a new version. The pull request then needs to be reviewed, tested and merged - as we're used to.

 * The checks will be executed monthly as that is the least frequest option.
 * The configuration options are documented [here](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file).