### PR TITLE
Enable DEBUG if the environment variable is set

### DIFF
--- a/webui/settings.py
+++ b/webui/settings.py
@@ -28,7 +28,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SECRET_KEY = os.getenv('SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = False
+DEBUG = os.getenv('PCW_DEBUG', False)
 
 CONFIG_FILE = '/etc/pcw.ini'
 


### PR DESCRIPTION
Currently `DEBUG` is set to `False` and to enable debugging we have to rebuild the image.  

With this change we'd only have to recreate the container (in our Ansible setup: by editing the pcw systemd service unit,  running `systemctl daemon-reload` and restarting the pcw service).