### PR TITLE
Switch _k8s container to Python 3.6 and add this version to liters

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,10 +4,15 @@ on: [push, pull_request]
 
 jobs:
   pylint:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10"]
+        include:
+          - python-version: '3.10'
+            os: 'ubuntu-latest'
+          - python-version: '3.6.15'
+            os: 'ubuntu-20.04'
+    runs-on: ${{ matrix.os }}
+    name: pylint
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
@@ -15,13 +20,18 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        run: |
-          pip install -r requirements_test.txt
+        run: pip install -r requirements_test.txt
       - name: Analysing the code with pylint
-        run: |
-          pylint ./ocw/lib/*.py cleanup_k8s.py
+        run: pylint ./ocw/lib/*.py cleanup_k8s.py
   flake8-lint:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - python-version: '3.10'
+            os: 'ubuntu-latest'
+          - python-version: '3.6.15'
+            os: 'ubuntu-20.04'
+    runs-on: ${{ matrix.os }}
     name: flake8
     steps:
       - name: Check out source repository
@@ -29,7 +39,7 @@ jobs:
       - name: Set up Python environment
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: ${{ matrix.python-version }}
       - name: flake8 Lint
         uses: py-actions/flake8@v2
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,15 +14,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: pylint
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: pip install -r requirements_test.txt
-      - name: Analysing the code with pylint
-        run: pylint ./ocw/lib/*.py cleanup_k8s.py
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: pip install -r requirements_test.txt
+    - name: Analysing the code with pylint
+      run: pylint ./ocw/lib/*.py cleanup_k8s.py
   flake8-lint:
     strategy:
       matrix:

--- a/.github/workflows/pcw.yml
+++ b/.github/workflows/pcw.yml
@@ -1,17 +1,19 @@
 ---
-
 name: PCW
-on:
-  - push
-  - pull_request
+
+on: [push, pull_request]
 
 jobs:
   pytest:
     name: pytest
-    runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10']
+        include:
+          - python-version: '3.10'
+            os: 'ubuntu-latest'
+          - python-version: '3.6.15'
+            os: 'ubuntu-20.04'
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python

--- a/Dockerfile_k8s
+++ b/Dockerfile_k8s
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/python:3.10
+FROM registry.suse.com/bci/python:3.6
 
 RUN zypper -n in gcc tar gzip kubernetes1.23-client aws-cli && rm -rf /var/cache
 
@@ -8,7 +8,7 @@ RUN curl -s https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cl
 
 # Install python dependences
 COPY requirements_k8s.txt /pcw/
-RUN  pip3.10 install --no-cache-dir -r /pcw/requirements_k8s.txt
+RUN  pip3.6 install --no-cache-dir -r /pcw/requirements_k8s.txt
 
 # Copy program files only
 COPY ocw  /pcw/ocw/

--- a/Dockerfile_k8s_dev
+++ b/Dockerfile_k8s_dev
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/python:3.10
+FROM registry.suse.com/bci/python:3.6
 
 RUN zypper -n in gcc tar gzip kubernetes1.23-client aws-cli && rm -rf /var/cache
 
@@ -8,7 +8,7 @@ RUN curl -s https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cl
 
 # Install python dependences
 COPY requirements_k8s.txt requirements.txt requirements_test.txt /pcw/
-RUN  pip3.10 install --no-cache-dir -r /pcw/requirements_test.txt
+RUN  pip3.6 install --no-cache-dir -r /pcw/requirements_test.txt
 
 ENV PATH ${PATH}:/opt/google-cloud-sdk/bin/
 

--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,6 @@ prepare:
 
 .PHONY: test
 test:
-	flake8 --max-line-length=130 webui
-	flake8 --max-line-length=130 ocw
-	flake8 --max-line-length=130 manage.py
-	flake8 --max-line-length=130 cleanup_k8s.py
 	pytest --cov
 
 .PHONY: codecov

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,9 @@ azure-storage-blob==12.13.0
 azure-identity==1.10.0
 msrestazure==0.6.4
 uwsgi==2.0.21
-requests==2.28.1
-django==4.0.6
+requests==2.27.1; python_version < '3.7'
+requests==2.28.1; python_version > '3.6'
+django==3.2.18
 django-tables2==2.4.1
 django-filter==22.1
 django-bootstrap4==22.1


### PR DESCRIPTION
- Run the linters on both Python 3.10 as well as 3.6
- Switch _k8s containers to Python 3.6

As we base our imaged on BCI which uses SLE15-SP4 and install other packages which are packaged for this service packs they require Python 3.6 as it is the default in SLE15-SP4 so we better use it in this image.

This pull request is in draft mode as there are more important things to do right now.
