### PR TITLE
Run containers as non-root & reduce the size of pcw image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,5 +28,8 @@ VOLUME /pcw/db
 
 EXPOSE 8000/tcp
 
+RUN useradd --no-create-home --uid 1777 --user-group --shell /bin/false pcw && chown -R pcw:pcw /pcw
+USER pcw
+
 # Once we are certain that this runs nicely, replace this with ENTRYPOINT.
 CMD ["/pcw/container-startup", "run"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY requirements.txt /pcw/
 # * Install system requirements
 # * Install pip requirements
 # * Empty system cache to conserve some space
-RUN zypper -n in python310-devel gcc libffi-devel aws-cli && pip3.10 install -r /pcw/requirements.txt && rm -rf /var/cache
+RUN zypper -n in python310-devel gcc libffi-devel aws-cli && pip install --no-cache-dir -r /pcw/requirements.txt && rm -rf /var/cache
 
 # Copy program files only
 COPY ocw  /pcw/ocw/

--- a/Dockerfile_dev
+++ b/Dockerfile_dev
@@ -14,4 +14,7 @@ RUN zypper -n in python310-devel gcc libffi-devel aws-cli && pip install --no-ca
 
 WORKDIR /pcw
 
+RUN useradd --no-create-home --uid 1000 --user-group --shell /bin/false pcw && chown -R pcw:pcw /pcw
+USER pcw
+
 ENTRYPOINT ["sh", "-c"]

--- a/Dockerfile_dev
+++ b/Dockerfile_dev
@@ -10,7 +10,7 @@ COPY requirements.txt requirements_test.txt requirements_k8s.txt /tmp/
 # * Install system requirements
 # * Install pip requirements
 # * Empty system cache to conserve some space
-RUN zypper -n in python310-devel gcc libffi-devel aws-cli && pip3.10 install -r /tmp/requirements_test.txt && rm -rf /var/cache
+RUN zypper -n in python310-devel gcc libffi-devel aws-cli && pip install --no-cache-dir -r /tmp/requirements_test.txt && rm -rf /var/cache
 
 WORKDIR /pcw
 

--- a/Dockerfile_k8s
+++ b/Dockerfile_k8s
@@ -17,4 +17,8 @@ COPY cleanup_k8s.py LICENSE README.md setup.cfg /pcw/
 ENV PATH ${PATH}:/opt/google-cloud-sdk/bin/
 
 WORKDIR /pcw
+
+RUN useradd --no-create-home --uid 1777 --user-group --shell /bin/false pcw && chown -R pcw:pcw /pcw
+USER pcw
+
 CMD ["python3", "cleanup_k8s.py"]

--- a/Dockerfile_k8s_dev
+++ b/Dockerfile_k8s_dev
@@ -14,4 +14,7 @@ ENV PATH ${PATH}:/opt/google-cloud-sdk/bin/
 
 WORKDIR /pcw
 
+RUN useradd --no-create-home --uid 1000 --user-group --shell /bin/false pcw && chown -R pcw:pcw /pcw
+USER pcw
+
 ENTRYPOINT ["sh", "-c"]


### PR DESCRIPTION
This PR:
- Makes it possible to run the containers as non-root
- Adds `--no-cache-dir` to `pip install` to reduce the size by 53M

Fixes: https://github.com/SUSE/pcw/issues/206

Related MR:
https://gitlab.suse.de/qac/publiccloud-qa-suse-de/-/merge_requests/70