### PR TITLE
Update Django to 4.0.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ azure-identity==1.10.0
 msrestazure==0.6.4
 uwsgi==2.0.21
 requests==2.28.1
-django==4.0.6
+django~=4.0.10
 django-tables2==2.4.1
 django-filter==22.1
 django-bootstrap4==22.1


### PR DESCRIPTION
The fixes for 4.0.x are only for CVE's.  From 4.0.6 to 4.0.10 we have:

- CVE-2022-36359: Potential reflected file download vulnerability in FileResponse
- CVE-2022-41323: Potential denial-of-service vulnerability in internationalized URLs
- CVE-2023-23969: Potential denial-of-service via Accept-Language headers
- CVE-2023-24580: Potential denial-of-service vulnerability in file uploads

https://docs.djangoproject.com/en/4.0/releases/