### PR TITLE
Temporarly drop codecov from github actions to unblock release pipeline


### DIFF
--- a/.github/workflows/pcw.yml
+++ b/.github/workflows/pcw.yml
@@ -25,21 +25,3 @@ jobs:
         run: make prepare
       - name: Run test
         run: make test
-  codecow:
-    name: codecow
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ['3.10']
-    steps:
-      - uses: actions/checkout@v3
-      - name: Setup Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install requirements
-        run: sudo apt-get install -y build-essential
-      - name: Preparation
-        run: make prepare
-      - name: Codecov
-        run: codecov

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -5,7 +5,6 @@ pytest-django
 faker
 flake8
 pytest-cov
-codecov
 pylint
 docker
 selenium


### PR DESCRIPTION
Temporarly drop codecov from github actions to unblock release pipeline
