### PR TITLE
Use fixed docker-py major version

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -6,5 +6,5 @@ faker
 flake8
 pytest-cov
 pylint
-docker
+docker~=6.0.1
 selenium


### PR DESCRIPTION
Version 6.1.0 of `docker-py` introduced breaking changes that makes our PR's fail:

https://github.com/docker/docker-py/blob/main/docs/change-log.md?plain=1#L22