### PR TITLE
Add hadolint for Dockerfiles

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,7 @@
+---
 name: Lint
 
-on: [push, pull_request]
+'on': [push, pull_request]
 
 jobs:
   pylint:
@@ -34,3 +35,19 @@ jobs:
         uses: py-actions/flake8@v2
         with:
           max-line-length: "130"
+  hadolint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: 'Dockerfile'
+      - uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: 'Dockerfile_dev'
+      - uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: 'Dockerfile_k8s'
+      - uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: 'Dockerfile_k8s_dev'

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,7 @@
+failure-threshold: warning
+format: tty
+
+# Ignored rules:
+# DL3037 - Specify package version because we don't want to do that
+# DL4006 - Use SHELL option `-o pipefail` because that's non OCI container option
+ignored: [DL3037, DL4006]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY requirements.txt /pcw/
 # * Install system requirements
 # * Install pip requirements
 # * Empty system cache to conserve some space
-RUN zypper -n in gcc libffi-devel && pip install --no-cache-dir -r /pcw/requirements.txt && rm -rf /var/cache
+RUN zypper -n in gcc libffi-devel && pip install --no-cache-dir -r /pcw/requirements.txt && zypper clean && rm -rf /var/cache
 
 # Copy program files only
 COPY ocw  /pcw/ocw/

--- a/Dockerfile_dev
+++ b/Dockerfile_dev
@@ -10,7 +10,7 @@ COPY requirements.txt requirements_test.txt requirements_k8s.txt /tmp/
 # * Install system requirements
 # * Install pip requirements
 # * Empty system cache to conserve some space
-RUN zypper -n in gcc libffi-devel && pip install --no-cache-dir -r /tmp/requirements_test.txt && rm -rf /var/cache
+RUN zypper -n in gcc libffi-devel && pip install --no-cache-dir -r /tmp/requirements_test.txt && zypper clean && rm -rf /var/cache
 
 WORKDIR /pcw
 

--- a/Dockerfile_k8s
+++ b/Dockerfile_k8s
@@ -1,9 +1,9 @@
 FROM registry.suse.com/bci/python:3.10
 
-RUN zypper -n in gcc tar gzip kubernetes1.23-client aws-cli azure-cli && rm -rf /var/cache
+RUN zypper -n in gcc tar gzip kubernetes1.23-client aws-cli azure-cli && zypper clean && rm -rf /var/cache
 
 # Google cli installation
-RUN curl -s https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-415.0.0-linux-x86_64.tar.gz | tar -zxf - -C /opt \
+RUN curl -sf https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-415.0.0-linux-x86_64.tar.gz | tar -zxf - -C /opt \
 && /opt/google-cloud-sdk/bin/gcloud components install gke-gcloud-auth-plugin
 
 # Install python dependences

--- a/Dockerfile_k8s_dev
+++ b/Dockerfile_k8s_dev
@@ -1,6 +1,6 @@
 FROM registry.suse.com/bci/python:3.10
 
-RUN zypper -n in gcc tar gzip kubernetes1.23-client aws-cli azure-cli && rm -rf /var/cache
+RUN zypper -n in gcc tar gzip kubernetes1.23-client aws-cli azure-cli && zypper clean && rm -rf /var/cache
 
 # Google cli installation
 RUN curl -s https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-415.0.0-linux-x86_64.tar.gz | tar -zxf - -C /opt \

--- a/Makefile
+++ b/Makefile
@@ -31,3 +31,8 @@ podman-container-k8s:
 	podman build -f Dockerfile_k8s -t pcw-k8s-cleaner
 podman-container-k8s-devel:
 	podman build -f Dockerfile_k8s_dev -t pcw-k8s-cleaner-devel
+
+# Container linting
+.PHONY: container-lint
+container-lint: Dockerfile*
+	hadolint Dockerfile*


### PR DESCRIPTION
Lint existing Dockerfiles using [hadolint](https://github.com/hadolint/hadolint) and provide configuration files for it.

In addition we add the hadolint Dockerfile linter into the pcw CI.