### PR TITLE
Kubernetes 1.23 is no longer available in base image

### DIFF
--- a/Dockerfile_k8s
+++ b/Dockerfile_k8s
@@ -1,6 +1,6 @@
 FROM registry.suse.com/bci/python:3.10
 
-RUN zypper -n in gcc tar gzip kubernetes1.23-client aws-cli azure-cli && zypper clean && rm -rf /var/cache
+RUN zypper -n in gcc tar gzip kubernetes1.24-client aws-cli azure-cli && zypper clean && rm -rf /var/cache
 
 # Google cli installation
 RUN curl -sf https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-415.0.0-linux-x86_64.tar.gz | tar -zxf - -C /opt \

--- a/Dockerfile_k8s_dev
+++ b/Dockerfile_k8s_dev
@@ -1,6 +1,6 @@
 FROM registry.suse.com/bci/python:3.10
 
-RUN zypper -n in gcc tar gzip kubernetes1.23-client aws-cli azure-cli && zypper clean && rm -rf /var/cache
+RUN zypper -n in gcc tar gzip kubernetes1.24-client aws-cli azure-cli && zypper clean && rm -rf /var/cache
 
 # Google cli installation
 RUN curl -s https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-415.0.0-linux-x86_64.tar.gz | tar -zxf - -C /opt \


### PR DESCRIPTION
Fixes `'kubernetes1.23-client' not found in package names. Trying capabilities.`