### PR TITLE
gce: Also delete GCE network resources

### DIFF
--- a/ocw/lib/gce.py
+++ b/ocw/lib/gce.py
@@ -57,6 +57,8 @@ class GCE(Provider):
         except HttpError as err:
             if GCE.get_error_reason(err) == 'resourceInUseByAnotherResource':
                 self.log_dbg(f"{resource_type.title()} '{resource_name}' can not be deleted because in use")
+            elif GCE.get_error_reason(err) == 'badRequest':
+                self.log_err(f"{resource_type.title()} '{resource_name}' can not be deleted because of unknown reason")
             else:
                 raise err
 


### PR DESCRIPTION
This PR deletes these letf-over network resources on GCE: firewall rules, routes, subnetworks & networks, with care taken not to delete any resource associated with the `default` network.

Current networks in ei-sle-qa: default, networktest1 & qe-c-testing-k8s-network.

Related ticket: https://progress.opensuse.org/issues/127220