### PR TITLE
eks: Delete the services associated with the cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,15 @@
 CONT_TAG=suse/qac/pcw
 
 .PHONY: all
-all: prepare test
+all: prepare test pylint
 
 .PHONY: prepare
 prepare:
 	pip install -r requirements_test.txt
+
+.PHONY: pylint
+pylint:
+	pylint ocw/lib/*.py cleanup_k8s.py
 
 .PHONY: test
 test:


### PR DESCRIPTION
This PR:
- Deletes the services associated with a cluster in EKS
- Minor code tidying to avoid indentation & f-strings.

Related ticket: https://progress.opensuse.org/issues/127268