### PR TITLE
Discover cancelled jobs to remove resources earlier than expired TTL

### DIFF
--- a/.github/workflows/pcw.yml
+++ b/.github/workflows/pcw.yml
@@ -14,7 +14,6 @@ jobs:
         python-version: ['3.10']
     steps:
       - uses: actions/checkout@v3
-      - uses: browser-actions/setup-geckodriver@latest
       - name: Setup Python
         uses: actions/setup-python@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ static/
 .coverage
 tests/auth.json
 tests/pcw.ini
-htmlcov/*
+htmlcov/
 
 # Configuration and program data
 /db

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,7 @@ pylint:
 
 .PHONY: flake8
 flake8:
-	flake8 --max-line-length=$(LINE_MAX) $(FILES)
-	flake8 --max-line-length=$(LINE_MAX) manage.py
+	flake8 --max-line-length=$(LINE_MAX) .
 
 .PHONY: test
 test:

--- a/ocw/lib/emailnotify.py
+++ b/ocw/lib/emailnotify.py
@@ -24,7 +24,7 @@ def draw_instance_table(objects):
             obj.instance_id,
             obj.cspinfo.get_tag('openqa_created_by', 'N/A'),
             obj.vault_namespace,
-            obj.age_formated(),
+            obj.age_formatted(),
             build_absolute_uri(reverse(views.delete, args=[obj.id])),
             "" if link is None else link['url']
         ])

--- a/ocw/lib/openqa.py
+++ b/ocw/lib/openqa.py
@@ -1,0 +1,50 @@
+from urllib.parse import urlparse
+from cachetools import cached
+import requests
+from requests.exceptions import RequestException
+from openqa_client.client import OpenQA_Client
+from openqa_client.const import JOB_STATE_CANCELLED
+from openqa_client.exceptions import OpenQAClientError
+
+
+@cached(cache={})
+def get_url(server):
+    if server:
+        server = server.rstrip('/').replace("_", ".")
+    if urlparse(server).scheme != "":
+        return server
+    for scheme in ("https", "http"):
+        try:
+            url = f"{scheme}://{server}"
+            got = requests.head(url, timeout=30)
+            got.raise_for_status()
+            return url
+        except RequestException:
+            pass
+    raise OpenQAClientError(f"Could not connect to server {server}")
+
+
+class OpenQA:
+    __servers = {}
+
+    def __new__(cls, **kwargs):
+        server = urlparse(get_url(kwargs["server"])).netloc
+        if server not in cls.__servers:
+            cls.__servers[server] = self = super().__new__(cls)
+            self.server = server
+        return cls.__servers[server]
+
+    def __init__(self, **kwargs):
+        kwargs.pop("server")
+        self.__client = OpenQA_Client(server=self.server, **kwargs)
+
+    def is_cancelled(self, job_id: str) -> bool:
+        if not job_id.isdigit():
+            raise ValueError(f"job must be a number: {job_id}")
+        try:
+            status = self.__client.openqa_request('GET', f'jobs/{job_id}')
+            # Return true if job is either cancelled or done
+            return status['job']['state'] == JOB_STATE_CANCELLED
+        except (TypeError, KeyError, OpenQAClientError):
+            pass
+        return False

--- a/ocw/models.py
+++ b/ocw/models.py
@@ -1,19 +1,23 @@
 import json
+import logging
 from datetime import datetime, timedelta, timezone
 from django.db import models
-from webui.PCWConfig import PCWConfig
 from .enums import ProviderChoice, StateChoice
+from .lib.openqa import OpenQA, get_url, OpenQAClientError
 
 
 def format_seconds(seconds):
+    if not seconds:
+        return "0s"
     days, remainder = divmod(seconds, 60*60*24)
     hours, remainder = divmod(remainder, 60*60)
     minutes, seconds = divmod(remainder, 60)
-    if days > 0:
-        return f'{days:.0f}d{hours:.0f}h{minutes:.0f}m'
-    if hours > 0:
-        return f'{hours:.0f}h{minutes:.0f}m'
-    return f'{minutes:.0f}m'
+    return "".join([
+        f"{days:.0f}d" if days > 0 else "",
+        f"{hours:.0f}h" if hours > 0 else "",
+        f"{minutes:.0f}m" if minutes > 0 else "",
+        f"{seconds:.0f}s" if seconds > 0 else "",
+    ])
 
 
 class Instance(models.Model):
@@ -32,11 +36,14 @@ class Instance(models.Model):
     ignore = models.BooleanField(default=False)
     TAG_IGNORE = 'pcw_ignore'
 
-    def age_formated(self):
+    def age_formatted(self):
         return format_seconds(self.age.total_seconds())
 
-    def ttl_formated(self):
-        return format_seconds(self.ttl.total_seconds()) if (self.ttl) else ""
+    def ttl_formatted(self):
+        return format_seconds(self.ttl.total_seconds())
+
+    def ttl_expired(self):
+        return self.age.total_seconds() > self.ttl.total_seconds()
 
     def all_time_fields(self):
         all_time_pattern = "(age={}, first_seen={}, last_seen={}, ttl={})"
@@ -46,7 +53,7 @@ class Instance(models.Model):
             first_fmt = self.first_seen.strftime('%Y-%m-%d %H:%M')
         if self.last_seen:
             last_fmt = self.last_seen.strftime('%Y-%m-%d %H:%M')
-        return all_time_pattern.format(self.age_formated(), first_fmt, last_fmt, self.ttl_formated())
+        return all_time_pattern.format(self.age_formatted(), first_fmt, last_fmt, self.ttl_formatted())
 
     def set_alive(self):
         self.last_seen = datetime.now(tz=timezone.utc)
@@ -58,6 +65,20 @@ class Instance(models.Model):
 
     def get_type(self):
         return self.cspinfo.type
+
+    def is_cancelled(self) -> bool:
+        job = self.cspinfo.get_tag("openqa_var_job_id")
+        server = self.cspinfo.get_tag("openqa_var_server")
+        if job and server:
+            try:
+                return OpenQA(
+                    server=server,
+                    retries=1,  # default is 5
+                    wait=5,     # default is 10
+                ).is_cancelled(job)
+            except OpenQAClientError as exc:
+                logging.warning("%s: %s", server, exc)
+        return False
 
     class Meta:  # pylint: disable=too-few-public-methods
         unique_together = (('provider', 'instance_id', 'vault_namespace'),)
@@ -73,10 +94,18 @@ class CspInfo(models.Model):
     type = models.CharField(max_length=200)
 
     def get_openqa_job_link(self):
-        if self.get_tag('openqa_created_by') == 'openqa-suse-de' and self.get_tag('openqa_var_JOB_ID') is not None:
-            url = f"{PCWConfig.get_feature_property('webui', 'openqa_url')}/t{self.get_tag('openqa_var_JOB_ID')}"
-            title = self.get_tag('openqa_var_NAME', '')
-            return {'url': url, 'title': title}
+        server = self.get_tag('openqa_var_server')
+        if server:
+            try:
+                server = get_url(server)
+            except OpenQAClientError as exc:
+                logging.warning("%s: %s", server, exc)
+                return None
+            job_id = self.get_tag('openqa_var_job_id')
+            if job_id:
+                url = f"{server}/t{job_id}"
+                title = self.get_tag('openqa_var_name', '')
+                return {'url': url, 'title': title}
         return None
 
     def get_tag(self, tag_name, default_value=None):

--- a/ocw/tables.py
+++ b/ocw/tables.py
@@ -75,10 +75,10 @@ class InstanceTable(tables.Table):
     ignore = tables.BooleanColumn()
 
     def render_age(self, record):
-        return record.age_formated()
+        return record.age_formatted()
 
     def render_ttl(self, record):
-        return record.ttl_formated()
+        return record.ttl_formatted()
 
     class Meta:  # pylint: disable=too-few-public-methods
         model = Instance

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ azure-mgmt-storage==20.0.0
 azure-mgmt-resource==21.1.0
 azure-storage-blob==12.13.0
 azure-identity==1.10.0
+cachetools
 msrestazure==0.6.4
 uwsgi==2.0.21
 requests==2.31.0
@@ -15,6 +16,7 @@ texttable
 oauth2client
 google-api-python-client==2.55.0
 google-cloud-storage==2.4.0
+openqa_client
 openstacksdk~=1.2.0
 python-dateutil
 apscheduler

--- a/templates/pcw.ini
+++ b/templates/pcw.ini
@@ -57,7 +57,3 @@ vpc_cleanup = true
 [updaterun]
 # if openqa_ttl tag is not defined this TTL will be set to the instance
 default_ttl = 44100 # value is in seconds
-
-[webui]
-# URL base used to generate URL to openQA together with job ID from openqa_var_JOB_ID tag
-openqa_url=https://openqa.suse.de/

--- a/tests/generators.py
+++ b/tests/generators.py
@@ -20,7 +20,7 @@ def mock_get_feature_property(feature: str, property: str, namespace: str = None
 
 def generate_model_instance(jobid_tag, created_by_tag):
     json_dump_tags = json.dumps({
-        'openqa_var_JOB_ID': jobid_tag,
+        'openqa_var_job_id': jobid_tag,
         'openqa_created_by': created_by_tag
     })
     return Instance(

--- a/tests/test_emailnotify.py
+++ b/tests/test_emailnotify.py
@@ -4,12 +4,10 @@ from tests.generators import generate_model_instance
 
 def test_draw_instance_table():
     objects = [
-            generate_model_instance(123, 'openqa-suse-de'),
             generate_model_instance(666, 'i-dont-have-a-link')
             ]
     s = draw_instance_table(objects)
 
-    assert 'https://openqa.suse.de/t123' in s
     assert 'https://openqa.suse.de/t666' not in s
 
     for instance_id in [o.instance_id for o in objects]:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,203 @@
+from datetime import datetime, timedelta, timezone
+import pytest
+from unittest.mock import MagicMock
+from ocw.models import Instance, CspInfo, format_seconds, StateChoice
+
+
+@pytest.fixture(autouse=True)
+def no_requests(monkeypatch):
+    monkeypatch.setattr('ocw.lib.openqa.OpenQA_Client', lambda *args, **kwargs: MagicMock())
+    monkeypatch.setattr("ocw.lib.openqa.get_url", lambda x: x)
+
+
+def test_format_seconds():
+    # Test cases with different seconds values
+    assert format_seconds(0) == "0s"
+    assert format_seconds(59) == "59s"
+    assert format_seconds(60) == "1m"
+    assert format_seconds(65) == "1m5s"
+    assert format_seconds(3600) == "1h"
+    assert format_seconds(3665) == "1h1m5s"
+    assert format_seconds(86400) == "1d"
+    assert format_seconds(86465) == "1d1m5s"
+    assert format_seconds(90061) == "1d1h1m1s"
+
+    # Test case with a large value
+    assert format_seconds(123456789) == "1428d21h33m9s"
+
+
+@pytest.fixture
+def example_instance_data():
+    return {
+        'provider': 'PROVIDER',
+        'first_seen': datetime(2023, 1, 1, tzinfo=timezone.utc),
+        'last_seen': datetime(2023, 1, 2, tzinfo=timezone.utc),
+        'instance_id': 'INSTANCE_ID',
+        'region': 'REGION',
+        'vault_namespace': 'VAULT_NAMESPACE',
+    }
+
+
+@pytest.fixture
+def example_cspinfo_data():
+    return {
+        'type': 'TYPE',
+        'tags': '{"openqa_var_server": "http://example.com", "openqa_var_job_id": "12345", "openqa_var_name": "Test Job"}',
+    }
+
+
+@pytest.mark.django_db
+def test_age_formatted(example_instance_data):
+    instance = Instance.objects.create(**example_instance_data)
+
+    # Set the age of the instance to 1 day (86400 seconds)
+    instance.age = timedelta(days=1)
+    instance.save()
+    assert instance.age_formatted() == "1d"
+
+    # Set the age of the instance to 2 hours (7200 seconds)
+    instance.age = timedelta(hours=2)
+    instance.save()
+    assert instance.age_formatted() == "2h"
+
+    # Set the age of the instance to 1 hour and 30 minutes (5400 seconds)
+    instance.age = timedelta(hours=1, minutes=30)
+    instance.save()
+    assert instance.age_formatted() == "1h30m"
+
+    # Set the age of the instance to 2 minutes and 15 seconds
+    instance.age = timedelta(minutes=2, seconds=15)
+    instance.save()
+    assert instance.age_formatted() == "2m15s"
+
+    # Test when the age is 0 seconds
+    instance.age = timedelta(seconds=0)
+    instance.save()
+    assert instance.age_formatted() == "0s"
+
+
+@pytest.mark.django_db
+def test_ttl_formatted(example_instance_data):
+    instance = Instance.objects.create(**example_instance_data)
+    instance.ttl = timedelta(hours=3, minutes=30)
+    assert instance.ttl_formatted() == "3h30m"
+
+
+@pytest.mark.django_db
+def test_ttl_expired(example_instance_data):
+    instance = Instance.objects.create(**example_instance_data)
+    assert not instance.ttl_expired()
+    instance.age = timedelta(hours=5)
+    instance.ttl = timedelta(hours=3)
+    assert instance.ttl_expired()
+
+
+@pytest.mark.django_db
+def test_all_time_fields(example_instance_data):
+    instance = Instance.objects.create(**example_instance_data)
+    instance.age = timedelta(days=2, hours=5, minutes=30)
+    instance.ttl = timedelta(hours=3, minutes=30)
+    assert instance.all_time_fields() == "(age=2d5h30m, first_seen=2023-01-01 00:00, last_seen=2023-01-02 00:00, ttl=3h30m)"
+
+
+@pytest.mark.django_db
+def test_set_alive(example_instance_data, example_cspinfo_data):
+    instance = Instance.objects.create(**example_instance_data)
+    cspinfo = CspInfo.objects.create(instance=instance, **example_cspinfo_data)
+    cspinfo.save()
+    instance.set_alive()
+    assert instance.last_seen is not None
+    assert instance.active is True
+    assert instance.age.total_seconds() > 0
+    assert instance.state == StateChoice.ACTIVE
+
+
+@pytest.mark.django_db
+def test_get_type(example_instance_data, example_cspinfo_data):
+    instance = Instance.objects.create(**example_instance_data)
+    cspinfo = CspInfo.objects.create(instance=instance, **example_cspinfo_data)
+    cspinfo.type = "TYPEX"
+    cspinfo.save()
+    assert instance.get_type() == "TYPEX"
+
+
+@pytest.mark.django_db
+def test_is_cancelled_without_tags(example_instance_data, example_cspinfo_data):
+    instance = Instance.objects.create(**example_instance_data)
+    cspinfo = CspInfo.objects.create(instance=instance, **example_cspinfo_data)
+    cspinfo.save()
+    # Test when both "openqa_var_job_id" and "openqa_var_server" tags are missing
+    assert not instance.is_cancelled()
+
+
+@pytest.mark.django_db
+def test_is_cancelled_with_tags(example_instance_data, example_cspinfo_data, monkeypatch):
+    instance = Instance.objects.create(**example_instance_data)
+    cspinfo = CspInfo.objects.create(instance=instance, **example_cspinfo_data)
+
+    # Mock the OpenQA class to return cancellation status
+    class MockOpenQA:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        @staticmethod
+        def is_cancelled(job_id):
+            return job_id == "12345"  # Pretend job_id "12345" is cancelled
+
+    # Use monkeypatch to replace the original OpenQA class with the MockOpenQA class
+    monkeypatch.setattr('ocw.models.OpenQA', MockOpenQA)
+
+    # Test when "openqa_var_job_id" and "openqa_var_server" tags are present
+    assert instance.is_cancelled()
+
+    # Test when "openqa_var_job_id" is present, but "openqa_var_server" is missing
+    cspinfo.tags = '{"openqa_var_job_id": "54321"}'
+    cspinfo.save()
+    assert not instance.is_cancelled()
+
+    # Test when "openqa_var_server" is present, but "openqa_var_job_id" is missing
+    cspinfo.tags = '{"openqa_var_server": "http://example.com"}'
+    cspinfo.save()
+    assert not instance.is_cancelled()
+
+
+@pytest.mark.django_db
+def test_get_openqa_job_link(example_instance_data, example_cspinfo_data):
+    instance = Instance.objects.create(**example_instance_data)
+    cspinfo = CspInfo.objects.create(instance=instance, **example_cspinfo_data)
+
+    # Test when both "openqa_var_server" and "openqa_var_job_id" tags are present
+    link = cspinfo.get_openqa_job_link()
+    assert link is not None
+    assert link['url'] == "http://example.com/t12345"
+    assert link['title'] == "Test Job"
+
+    # Test when only "openqa_var_server" tag is present
+    cspinfo.tags = '{"openqa_var_server": "http://example.com"}'
+    cspinfo.save()
+    link = cspinfo.get_openqa_job_link()
+    assert link is None
+
+    # Test when only "openqa_var_job_id" tag is present
+    cspinfo.tags = '{"openqa_var_job_id": "12345"}'
+    cspinfo.save()
+    link = cspinfo.get_openqa_job_link()
+    assert link is None
+
+    # Test when both "openqa_var_server" and "openqa_var_job_id" tags are missing
+    cspinfo.tags = '{}'
+    cspinfo.save()
+    link = cspinfo.get_openqa_job_link()
+    assert link is None
+
+
+@pytest.mark.django_db
+def test_get_tag(example_instance_data, example_cspinfo_data):
+    instance = Instance.objects.create(**example_instance_data)
+    cspinfo = CspInfo.objects.create(instance=instance, **example_cspinfo_data)
+
+    assert cspinfo.get_tag('openqa_var_server') == "http://example.com"
+    assert cspinfo.get_tag('openqa_var_job_id') == "12345"
+    assert cspinfo.get_tag('openqa_var_name') == "Test Job"
+    assert cspinfo.get_tag('non_existent_tag') is None
+    assert cspinfo.get_tag('non_existent_tag', default_value="N/A") == "N/A"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -6,7 +6,7 @@ from ocw.models import Instance, CspInfo, format_seconds, StateChoice
 
 @pytest.fixture(autouse=True)
 def no_requests(monkeypatch):
-    monkeypatch.setattr('ocw.lib.openqa.OpenQA_Client', lambda *args, **kwargs: MagicMock())
+    monkeypatch.setattr('openqa_client.client.OpenQA_Client', lambda *args, **kwargs: MagicMock())
     monkeypatch.setattr("ocw.lib.openqa.get_url", lambda x: x)
 
 

--- a/tests/test_openqa.py
+++ b/tests/test_openqa.py
@@ -1,0 +1,111 @@
+from unittest.mock import MagicMock, patch
+import pytest
+from openqa_client.const import JOB_STATE_CANCELLED
+from openqa_client.exceptions import OpenQAClientError
+from requests.exceptions import RequestException
+from ocw.lib.openqa import OpenQA, get_url
+
+
+@pytest.fixture
+def openqa_client_mock():
+    yield MagicMock()
+
+
+@pytest.fixture
+def openqa_instance(openqa_client_mock):
+    with (
+        patch('ocw.lib.openqa.OpenQA_Client', return_value=openqa_client_mock),
+        patch('ocw.lib.openqa.get_url', return_value=None)
+    ):
+        yield OpenQA(server="myserver")
+
+
+def test_is_cancelled_returns_true_when_job_cancelled(openqa_instance, openqa_client_mock):
+    job_id = "123"
+    openqa_client_mock.openqa_request.return_value = {
+        'job': {'state': JOB_STATE_CANCELLED}
+    }
+
+    result = openqa_instance.is_cancelled(job_id)
+    assert result is True
+    assert openqa_instance._OpenQA__client.openqa_request.call_count == 1
+
+
+def test_is_cancelled_returns_false_when_job_not_cancelled(openqa_instance, openqa_client_mock):
+    job_id = "124"
+    openqa_client_mock.openqa_request.return_value = {
+        'job': {'state': 'running'}
+    }
+
+    result = openqa_instance.is_cancelled(job_id)
+    assert result is False
+    assert openqa_instance._OpenQA__client.openqa_request.call_count == 1
+
+
+def test_is_cancelled_raises_value_error_when_invalid_job_id(openqa_instance):
+    invalid_job_id = "abc"
+
+    with pytest.raises(ValueError):
+        openqa_instance.is_cancelled(invalid_job_id)
+    assert openqa_instance._OpenQA__client.openqa_request.call_count == 0
+
+
+def test_is_cancelled_returns_false_when_request_errors_occurred(openqa_instance, openqa_client_mock):
+    job_id = "125"
+    openqa_client_mock.openqa_request.side_effect = OpenQAClientError()
+
+    result = openqa_instance.is_cancelled(job_id)
+    assert result is False
+
+
+def test_singleton():
+    with patch("requests.head"):
+        osd = OpenQA(server="https://openqa.suse.de/")
+        get_url.cache_clear()
+        for url in ("https://openqa.suse.de", "https://openqa_suse_de", "openqa.suse.de", "openqa_suse_de"):
+            osd2 = OpenQA(server="openqa.suse.de")
+            assert osd2 is osd
+            get_url.cache_clear()
+        o3 = OpenQA(server="https://openqa.opensuse.org")
+        assert osd is not o3
+        get_url.cache_clear()
+
+
+def test_get_url_cache():
+    with patch("requests.head") as mock_head:
+        url = get_url("https://openqa.suse.de/")
+        url2 = get_url("https://openqa.suse.de")
+        url3 = get_url("openqa.suse.de")
+        assert url == url2 == url3
+        assert mock_head.call_count == 1
+
+
+def test_get_url_with_valid_scheme():
+    url = get_url("https://openqa.suse.de")
+    assert url == "https://openqa.suse.de"
+    get_url.cache_clear()
+
+
+def test_get_url_with_invalid_scheme():
+    with patch("requests.head") as mock_head:
+        mock_head.side_effect = OpenQAClientError
+        with pytest.raises(OpenQAClientError):
+            get_url("openqa.suse.de")
+    get_url.cache_clear()
+
+
+def test_get_url_with_valid_scheme_retry():
+    with patch("requests.head") as mock_head:
+        response_mock = mock_head.return_value
+        response_mock.raise_for_status.side_effect = [RequestException, None]
+        url = get_url("openqa.suse.de")
+        assert url == "http://openqa.suse.de"
+    get_url.cache_clear()
+
+
+def test_get_url_with_invalid_server():
+    with patch("requests.head") as mock_head:
+        mock_head.side_effect = OpenQAClientError
+        with pytest.raises(OpenQAClientError):
+            get_url("invalid-openqa.suse.de")
+    get_url.cache_clear()

--- a/tests/test_openqa.py
+++ b/tests/test_openqa.py
@@ -14,7 +14,7 @@ def openqa_client_mock():
 @pytest.fixture
 def openqa_instance(openqa_client_mock):
     with (
-        patch('ocw.lib.openqa.OpenQA_Client', return_value=openqa_client_mock),
+        patch('openqa_client.client.OpenQA_Client', return_value=openqa_client_mock),
         patch('ocw.lib.openqa.get_url', return_value=None)
     ):
         yield OpenQA(server="myserver")

--- a/webui/PCWConfig.py
+++ b/webui/PCWConfig.py
@@ -69,7 +69,6 @@ class PCWConfig():
             'notify/smtp': {'default': None, 'return_type': str},
             'notify/smtp-port': {'default': 25, 'return_type': int},
             'notify/from': {'default': 'pcw@publiccloud.qa.suse.de', 'return_type': str},
-            'webui/openqa_url': {'default': 'https://openqa.suse.de', 'return_type': str}
         }
         key = '/'.join([feature, property])
         if key not in default_values:


### PR DESCRIPTION
Currently, if we manually cancel VR's the instances may remain active until pcw cleans them up when the TTL expires.

This PR:
- Uses the openQA client to discover those cancelled jobs, which we get from the instance's tags.
- Adds `get_url()` to guess the protocol used by the openQA server if no scheme is present.
- Adds unit tests to `ocw.models`
- Removes redundant `browser-actions/setup-geckodriver` because of rate-limits.

TODO:
- Test it.