### PR TITLE
Fix deprecation warning in Selenium 4.11.x

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -7,4 +7,4 @@ flake8
 pytest-cov
 pylint
 docker~=6.0.1
-selenium
+selenium~=4.11.2

--- a/tests/test_webui.py
+++ b/tests/test_webui.py
@@ -1,8 +1,8 @@
-import os
 import random
 import pytest
 import docker
 
+from subprocess import DEVNULL
 from docker.errors import DockerException
 from selenium.webdriver import firefox
 from selenium.webdriver.common.by import By
@@ -52,7 +52,7 @@ def docker_container():
 
 @pytest.fixture
 def browser():
-    service = firefox.service.Service(log_path=os.devnull)
+    service = firefox.service.Service(log_output=DEVNULL)
     options = firefox.options.Options()
     options.add_argument('-headless')
     driver = firefox.webdriver.WebDriver(options=options, service=service)


### PR DESCRIPTION
The CI is broken by deprecation warning in newest Selenium 4.11.x.

This PR includes the fix and sets a Selenium version in `requirements_test.txt`.