### PR TITLE
Use Podman instead of Docker for Selenium test

### DIFF
--- a/.github/workflows/pcw.yml
+++ b/.github/workflows/pcw.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install requirements
-        run: sudo apt-get install -y build-essential
+        run: sudo apt-get install -y build-essential podman
       - name: Preparation
         run: make prepare
       - name: Run test

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -6,5 +6,5 @@ faker
 flake8
 pytest-cov
 pylint
-docker~=6.0.1
+podman~=4.6.0
 selenium~=4.11.2

--- a/tests/test_webui.py
+++ b/tests/test_webui.py
@@ -1,13 +1,16 @@
+import contextlib
+import json
 import random
+import os
+import sys
 import pytest
-import docker
 
 from subprocess import DEVNULL
-from docker.errors import DockerException
+from podman import PodmanClient
+from podman.errors import APIError, PodmanError
 from selenium.webdriver import firefox
 from selenium.webdriver.common.by import By
 
-IMAGE = "pcw:latest"
 USERNAME = "username"
 PASSWORD = "password"
 PORT = 8000
@@ -20,34 +23,59 @@ XPATH = {
 
 
 @pytest.fixture(scope="session")
-def docker_container():
+def podman_container():
     import warnings
     # Ignore ResourceWarning messages that can happen at random when closing resources
     warnings.filterwarnings(action="ignore", message="unclosed", category=ResourceWarning)
 
+    if os.getenv("SKIP_SELENIUM"):
+        pytest.skip("Skipping because SKIP_SELENIUM is set")
+
     try:
-        client = docker.from_env()
-    except DockerException:
-        pytest.skip("No Docker environment. Skipping...")
-    # Build image
-    client.images.build(path=".", tag=IMAGE)
-    # Get random ephemeral port
+        client = PodmanClient()
+    except (APIError, PodmanError):
+        pytest.skip("No Podman environment. Skipping...")
+
+    # Get random number for ephemeral port, container and image name
     port = random.randint(32768, 60999)  # Typical values from /proc/sys/net/ipv4/ip_local_port_range
-    # Run container
-    container = client.containers.run(
-        IMAGE,
-        detach=True,
-        remove=True,
-        ports={f"{PORT}/tcp": port}
-    )
-    # Create user in database
-    container.exec_run(f"/pcw/container-startup createuser {USERNAME} {PASSWORD}")
-    yield container
+    image_name = f"pcw-test{port}"
+
+    # Build image
     try:
+        client.images.build(
+            path=".",
+            dockerfile="Dockerfile",
+            tag=image_name,
+        )
+    except (APIError, PodmanError) as exc:
+        for log in exc.build_log:
+            line = json.loads(log.decode("utf-8"))
+            if line:
+                print(line.get("stream"), file=sys.stderr, end='')
+        pytest.fail(f"{exc}")
+
+    try:
+        # Run container
+        container = client.containers.run(
+            image=image_name,
+            name=image_name,
+            detach=True,
+            remove=True,
+            ports={f"{PORT}/tcp": port}
+        )
+        # Create user in database
+        container.exec_run(f"/pcw/container-startup createuser {USERNAME} {PASSWORD}")
+    except (APIError, PodmanError) as exc:
+        pytest.fail(f"{exc}")
+
+    yield container
+
+    # Cleanup
+    with contextlib.suppress(APIError, PodmanError):
         container.stop()
+        container.remove()
+        client.images.remove(image_name)
         client.close()
-    except DockerException:
-        pass
 
 
 @pytest.fixture
@@ -60,9 +88,9 @@ def browser():
     driver.quit()
 
 
-def test_login_logout(docker_container, browser):  # pylint: disable=redefined-outer-name
-    # Get randomly assigned port. NOTE: docker_container.ports doesn't work
-    port = docker_container.attrs['HostConfig']['PortBindings'][f'{PORT}/tcp'][0]['HostPort']
+def test_login_logout(podman_container, browser):  # pylint: disable=redefined-outer-name
+    # Get randomly assigned port. NOTE: podman_container.ports doesn't work
+    port = podman_container.attrs['HostConfig']['PortBindings'][f'{PORT}/tcp'][0]['HostPort']
     browser.get(f"http://127.0.0.1:{port}")
     browser.find_element(By.XPATH, XPATH["login"]).click()
     browser.find_element(By.NAME, value="username").send_keys(USERNAME)


### PR DESCRIPTION
This PR:
- Uses Podman instead of Docker for the Selenium test. 
- Fixes the cleanup code to remove the image afterwards.

Because this test builds a Docker image it may take some time if the layers aren't cached.  Set the `SKIP_SELENIUM` environment variable when running `pytest` or `make test`.
