### PR TITLE
Verify TLS by default to avoid warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ pylint:
 
 .PHONY: flake8
 flake8:
-	flake8 --max-line-length=$(LINE_MAX) .
+	flake8 --max-line-length=$(LINE_MAX) $(FILES) tests/*.py
 
 .PHONY: test
 test:


### PR DESCRIPTION
Verify TLS by default to avoid SSLError warnings when connecting to openQA.  These warnings can't be disabled in `requests` for openQA only because doing so would also disable them when connecting to cloud providers.