### PR TITLE
ec2: Handle exception in delete_vpc_subnets

### DIFF
--- a/ocw/lib/ec2.py
+++ b/ocw/lib/ec2.py
@@ -173,7 +173,11 @@ class EC2(Provider):
                     self.log_info(f'Deletion of {interface} skipped due to dry_run mode')
                 else:
                     self.log_info(f'Deleting {interface}')
-                    interface.delete()
+                    try:
+                        interface.delete()
+                    except ClientError as exc:
+                        self.log_err("delete_vpc_subnets: %s", exc)
+                        continue
             if self.dry_run:
                 self.log_info(f'Deletion of {subnet} skipped due to dry_run mode')
             else:

--- a/ocw/lib/gce.py
+++ b/ocw/lib/gce.py
@@ -100,7 +100,7 @@ class GCE(Provider):
             )
             return [basename(z) for z in region["zones"]]
         except (KeyError, HttpError) as exc:
-            self.log_dbg("list_zones: %s", exc)
+            self.log_err("list_zones: %s", exc)
             return []
 
     def delete_instance(self, instance_id, zone) -> None:


### PR DESCRIPTION
ec2: Handle exception in delete_vpc_subnets

Currently, if an exception occurs in `delete_vpc_subnets` the rest of the interfaces and subnets are not cleaned up. This PR fixes this.

```
[vpc-048a46ffba9f0e954] ClientError on VPC deletion. Traceback (most recent call last):
  File "/pcw/ocw/lib/ec2.py", line 154, in delete_vpc
    self.delete_vpc_subnets(vpc)
  File "/pcw/ocw/lib/ec2.py", line 176, in delete_vpc_subnets
    interface.delete()
  File "/usr/lib/python3.11/site-packages/boto3/resources/factory.py", line 580, in do_action
    response = action(self, *args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/boto3/resources/action.py", line 88, in __call__
    response = getattr(parent.meta.client, operation_name)(*args, **params)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/botocore/client.py", line 535, in _api_call
    return self._make_api_call(operation_name, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/botocore/client.py", line 980, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.exceptions.ClientError: An error occurred (InvalidParameterValue) when calling the DeleteNetworkInterface operation: Network interface 'eni-06a77d9991d095f46' is currently in use.
```