### PR TITLE
Include ignore field in instances.json

### DIFF
--- a/ocw/views.py
+++ b/ocw/views.py
@@ -51,7 +51,8 @@ def instance_json(request):
             "ttl",
             "instance_id",
             "region",
-            "vault_namespace"
+            "vault_namespace",
+            "ignore"
         ),
     )
     return HttpResponse(data, content_type="application/json")


### PR DESCRIPTION
The instances.json path should also include the ignore field to allow external applications to hide ignored instances.