### PR TITLE
Prefer http over https for OpenQA

### DIFF
--- a/ocw/lib/openqa.py
+++ b/ocw/lib/openqa.py
@@ -27,7 +27,7 @@ def get_url(server: str) -> str:
         server = server.rstrip('/').replace("_", ".")
     if urlparse(server).scheme != "":
         return server
-    for scheme in ("https", "http"):
+    for scheme in ("http", "https"):
         try:
             url = f"{scheme}://{server}"
             got = requests.head(
@@ -55,7 +55,8 @@ class OpenQA:
     def __init__(self, **kwargs):
         kwargs.pop("server")
         self.__client = openqa_client.client.OpenQA_Client(server=self.server, **kwargs)
-        self.__client.session.verify = verify_tls(self.server)
+        if self.server.startswith("https://"):
+            self.__client.session.verify = verify_tls(self.server)
 
     def is_cancelled(self, job_id: str) -> bool:
         if not job_id.isdigit():

--- a/tests/test_openqa.py
+++ b/tests/test_openqa.py
@@ -15,7 +15,7 @@ def openqa_client_mock():
 def openqa_instance(openqa_client_mock):
     with (
         patch('openqa_client.client.OpenQA_Client', return_value=openqa_client_mock),
-        patch('ocw.lib.openqa.get_url', return_value=None),
+        patch('ocw.lib.openqa.get_url', return_value=""),
         patch('ocw.lib.openqa.verify_tls', return_value=None),
     ):
         yield OpenQA(server="myserver")
@@ -74,16 +74,16 @@ def test_singleton():
 
 def test_get_url_cache():
     with patch("requests.head") as mock_head:
-        url = get_url("https://openqa.suse.de/")
-        url2 = get_url("https://openqa.suse.de")
+        url = get_url("http://openqa.suse.de/")
+        url2 = get_url("http://openqa.suse.de")
         url3 = get_url("openqa.suse.de")
         assert url == url2 == url3
         assert mock_head.call_count == 1
 
 
 def test_get_url_with_valid_scheme():
-    url = get_url("https://openqa.suse.de")
-    assert url == "https://openqa.suse.de"
+    url = get_url("http://openqa.suse.de")
+    assert url == "http://openqa.suse.de"
     get_url.cache_clear()
 
 
@@ -100,7 +100,7 @@ def test_get_url_with_valid_scheme_retry():
         response_mock = mock_head.return_value
         response_mock.raise_for_status.side_effect = [RequestException, None]
         url = get_url("openqa.suse.de")
-        assert url == "http://openqa.suse.de"
+        assert url == "https://openqa.suse.de"
     get_url.cache_clear()
 
 

--- a/tests/test_webui.py
+++ b/tests/test_webui.py
@@ -12,6 +12,13 @@ from podman.errors import APIError, PodmanError
 from selenium.webdriver import firefox
 from selenium.webdriver.common.by import By
 
+# This can be dropped when Selenium switches to no longer write to geckodriver.log
+import warnings
+# Ignore ResourceWarning messages that can happen at random when closing resources:
+#   Exception ignored in: <_io.FileIO name='/dev/null' mode='wb' closefd=True>
+warnings.filterwarnings(action="ignore", message="unclosed", category=ResourceWarning)
+
+
 USERNAME = "username"
 PASSWORD = "password"
 PORT = 8000


### PR DESCRIPTION
As we're only getting job statuses without using credentials we can prefer HTTP over HTTPS.  This avoids the warnings in the case of expired or self-signed certificates.

For the case of legitimate certificates signed by SUSE, we wait for:
https://github.com/os-autoinst/openQA-python-client/pull/47