### PR TITLE
Add codecov.yml allowing to make codecov check informational

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,26 @@
+coverage:
+  round: up
+  range: "70..100"
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 0%
+        paths:
+          - "ocw"
+        branches:
+          - master
+        if_ci_failed: ignore
+        informational: true
+        only_pulls: true
+    patch:
+      default:
+        target: auto
+        threshold: 0%
+        paths:
+          - "ocw"
+        branches:
+          - master
+        if_ci_failed: ignore
+        informational: true
+        only_pulls: true


### PR DESCRIPTION
In majority of PRs which we merging codecov checks are red but we merging them anyway , hence there is no point to make PRs red with reasons which we tend to ignore 