### PR TITLE
Return response on update_status in all cases

### DIFF
--- a/ocw/views.py
+++ b/ocw/views.py
@@ -64,13 +64,10 @@ def update(request):
 
 
 def update_status(request):
-    if 'application/json' in request.META.get('HTTP_ACCEPT'):
-        return JsonResponse({
-                  'status': 'running' if db.is_updating() else 'idle',
-                  'last_update': db.last_update()
-                  })
-
-    return redirect('instances')
+    return JsonResponse({
+                'status': 'running' if db.is_updating() else 'idle',
+                'last_update': db.last_update()
+                })
 
 
 @login_required


### PR DESCRIPTION
Always return a reply when update/status is queried.

Redirecting the `/update/status` to `/instances` in the case that a certain http header is not set is confusing and should not happen. The API path should always return something valid or at least throw an error if a input parameter is missing.