### PR TITLE
Unify exceptions handling during VPC deletion

### DIFF
--- a/ocw/lib/ec2.py
+++ b/ocw/lib/ec2.py
@@ -256,8 +256,7 @@ class EC2(Provider):
                     else:
                         self.log_info(f"Delete route {route_table['RouteTableId']}")
                         self.log_dbg(route)
-                        self.ec2_client(region).delete_route(RouteTableId=route_table['RouteTableId'],
-                                                             DestinationCidrBlock=route['DestinationCidrBlock'])
+                        self.ec2_client(region).delete_route(RouteTableId=route_table['RouteTableId'])
             if route_table['Associations'] == []:
                 if self.dry_run:
                     self.log_info(f"{route_table['RouteTableId']} routing table will not be deleted due to dry_run mode")

--- a/tests/test_ec2.py
+++ b/tests/test_ec2.py
@@ -170,7 +170,7 @@ class MockedEC2Client():
     def describe_route_tables(self, Filters):
         return MockedEC2Client.routing_tables
 
-    def delete_route(self, RouteTableId, DestinationCidrBlock):
+    def delete_route(self, RouteTableId):
         if RouteTableId == '2':
             MockedEC2Client.delete_route_called = True
 


### PR DESCRIPTION
There was two different attempts to handle known exceptions in VPC deletion. It appears that having both of them cause collisions. So I unify them into one.