### PR TITLE
Azure: Check if version.tags is None

### DIFF
--- a/ocw/lib/azure.py
+++ b/ocw/lib/azure.py
@@ -194,7 +194,7 @@ class Azure(Provider):
                 continue
             for version in self.compute_mgmt_client().gallery_image_versions.list_by_gallery_image(
                     self.__resource_group, gallery.name, image.name):
-                if Instance.TAG_IGNORE in version.tags:
+                if version.tags is not None and Instance.TAG_IGNORE in version.tags:
                     self.log_info(f"Image version {version} for image {image} in gallery {self.__gallery} has {Instance.TAG_IGNORE} tag")
                     continue
                 properties = self.get_resource_properties(version.id)


### PR DESCRIPTION
Fix for 

```
Traceback (most recent call last):
  File "/pcw/ocw/lib/cleanup.py", line 21, in cleanup_run
    Azure(namespace).cleanup_all()
  File "/pcw/ocw/lib/azure.py", line 125, in cleanup_all
    self.cleanup_gallery_img_versions()
  File "/pcw/ocw/lib/azure.py", line 197, in cleanup_gallery_img_versions
    if Instance.TAG_IGNORE in version.tags:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: argument of type 'NoneType' is not iterable
```
