### PR TITLE
Start counting image versions for Azure

### DIFF
--- a/ocw/lib/dump_state.py
+++ b/ocw/lib/dump_state.py
@@ -17,5 +17,6 @@ def dump_state():
                 Influx().dump_resource(ProviderChoice.AZURE.value, Influx.VMS_QUANTITY, Azure(namespace).list_instances)
                 Influx().dump_resource(ProviderChoice.AZURE.value, Influx.IMAGES_QUANTITY, Azure(namespace).list_images)
                 Influx().dump_resource(ProviderChoice.AZURE.value, Influx.DISK_QUANTITY, Azure(namespace).list_disks)
+                Influx().dump_resource(ProviderChoice.AZURE.value, Influx.IMAGE_VERSION_QUANTITY, Azure(namespace).get_img_versions_count)
         except Exception:
             logger.exception("[%s] Dump state failed!: \n %s", namespace, traceback.format_exc())

--- a/ocw/lib/influx.py
+++ b/ocw/lib/influx.py
@@ -17,6 +17,7 @@ class Influx:
     VMS_QUANTITY: str = "vms_quantity"
     IMAGES_QUANTITY: str = "images_quantity"
     DISK_QUANTITY: str = "disk_quantity"
+    IMAGE_VERSION_QUANTITY: str = "img_version_quantity"
 
     def __init__(self) -> None:
         if self.__client is None:
@@ -47,6 +48,12 @@ class Influx:
                 logger.warning("Failed to write to influxdb(record=%s): %s", point, exception)
 
     def dump_resource(self, provider: str, field: str, dump_method: Callable) -> None:
-        items_cnt = len(dump_method())
-        logger.debug("%d instances found in %s", items_cnt, provider)
+        return_value = dump_method()
+        if isinstance(return_value, list):
+            items_cnt = len(return_value)
+        elif isinstance(return_value, int):
+            items_cnt = return_value
+        else:
+            raise ValueError(f"{dump_method} returned unsupported type {type(return_value)}")
+        logger.debug("%s=%d for %s", field, items_cnt, provider)
         self.write(provider, field, items_cnt)


### PR DESCRIPTION
Currently existing counters ( image and blobs ) always returning 0s because we actually storing images currently as image versions so we need to add counter for this