### PR TITLE
Add namespace tag when dumping cloud stat

### DIFF
--- a/ocw/lib/dump_state.py
+++ b/ocw/lib/dump_state.py
@@ -9,14 +9,36 @@ logger = logging.getLogger(__name__)
 
 
 def dump_state():
-    for namespace in PCWConfig.get_namespaces_for('influxdb'):
+    for namespace in PCWConfig.get_namespaces_for("influxdb"):
         try:
-            providers = PCWConfig.get_providers_for('influxdb', namespace)
-            logger.info("[%s] Dump state %s", namespace, ','.join(providers))
+            providers = PCWConfig.get_providers_for("influxdb", namespace)
+            logger.info("[%s] Dump state %s", namespace, ",".join(providers))
             if ProviderChoice.AZURE in providers:
-                Influx().dump_resource(ProviderChoice.AZURE.value, Influx.VMS_QUANTITY, Azure(namespace).list_instances)
-                Influx().dump_resource(ProviderChoice.AZURE.value, Influx.IMAGES_QUANTITY, Azure(namespace).list_images)
-                Influx().dump_resource(ProviderChoice.AZURE.value, Influx.DISK_QUANTITY, Azure(namespace).list_disks)
-                Influx().dump_resource(ProviderChoice.AZURE.value, Influx.IMAGE_VERSION_QUANTITY, Azure(namespace).get_img_versions_count)
+                Influx().dump_resource(
+                    ProviderChoice.AZURE.value,
+                    Influx.VMS_QUANTITY,
+                    namespace,
+                    Azure(namespace).list_instances,
+                )
+                Influx().dump_resource(
+                    ProviderChoice.AZURE.value,
+                    Influx.IMAGES_QUANTITY,
+                    namespace,
+                    Azure(namespace).list_images,
+                )
+                Influx().dump_resource(
+                    ProviderChoice.AZURE.value,
+                    Influx.DISK_QUANTITY,
+                    namespace,
+                    Azure(namespace).list_disks,
+                )
+                Influx().dump_resource(
+                    ProviderChoice.AZURE.value,
+                    Influx.IMAGE_VERSION_QUANTITY,
+                    namespace,
+                    Azure(namespace).get_img_versions_count,
+                )
         except Exception:
-            logger.exception("[%s] Dump state failed!: \n %s", namespace, traceback.format_exc())
+            logger.exception(
+                "[%s] Dump state failed!: \n %s", namespace, traceback.format_exc()
+            )


### PR DESCRIPTION


From the beginning we querying over all namespaces defined for PCW.
But currently we saving everything together no matter from which namespace
measurement have come. This does not make sense we should add tag which will
allow to distinguish one namespace from another
