### PR TITLE
Update uwsgi to 2.0.24

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ azure-storage-blob==12.19.0
 azure-identity==1.14.1
 cachetools
 msrestazure==0.6.4
-uwsgi==2.0.22
+uwsgi==2.0.24
 requests==2.31.0
 Django~=4.2.2
 django-tables2==2.6.0


### PR DESCRIPTION
This fixes compilation of uwsgi wheel on newer systems with Python 3.12.

- https://uwsgi-docs.readthedocs.io/en/latest/Changelog-2.0.23.html
- https://uwsgi-docs.readthedocs.io/en/latest/Changelog-2.0.24.html
