### PR TITLE
azure: Clean image versions in Failed provisioning state

### DIFF
--- a/ocw/lib/azure.py
+++ b/ocw/lib/azure.py
@@ -199,8 +199,8 @@ class Azure(Provider):
                 if version.tags is not None and Instance.TAG_IGNORE in version.tags:
                     self.log_info(f"Image version {version} for image {image} in gallery {self.__gallery} has {Instance.TAG_IGNORE} tag")
                     continue
-                properties = self.get_resource_properties(version.id)
-                if self.is_outdated(parse(properties['publishingProfile']['publishedDate'])):
+                if version.provisioning_state == "Failed" or \
+                        self.is_outdated(parse(self.get_resource_properties(version.id)['publishingProfile']['publishedDate'])):
                     if self.dry_run:
                         self.log_info(f"Deletion of version {gallery.name}/{image.name}/{version.name} skipped due to dry run mode")
                     else:


### PR DESCRIPTION
Clean image versions in Failed provisioning state

Observation: A lot of Azure objects have this `provisioning_state` attribute that we can take advantage of in other scenarios.

Related ticket: https://progress.opensuse.org/issues/160397