### PR TITLE
Implement pcw_ignore for cleanup_images in gce

### DIFF
--- a/ocw/lib/gce.py
+++ b/ocw/lib/gce.py
@@ -187,9 +187,14 @@ class GCE(Provider):
         self.log_dbg(f"{len(images)} images found")
         for image in images:
             if self.is_outdated(parse(image["creationTimestamp"]).astimezone(timezone.utc)):
-                self._delete_resource(
-                    self.compute_client().images, image["name"], project=self.project, image=image["name"]
-                )
+                labels = image.get('labels', [])
+                pcw_ignore_tag = 'pcw_ignore' in labels
+                if pcw_ignore_tag:
+                    self.log_dbg(f"Ignoring {image['name']} due to 'pcw_ignore' label set to '1'")
+                else:
+                    self._delete_resource(
+                        self.compute_client().images, image["name"], project=self.project, image=image["name"]
+                    )
 
     def cleanup_firewalls(self) -> None:
         self.log_dbg("Firewalls cleanup")


### PR DESCRIPTION
 * Related ticket: [poo#162770](https://progress.opensuse.org/issues/162770)
 * Verification run:

```
$ podman run  -v ./pcw.ini:/etc/pcw.ini -v ./creds/:/var/pcw -v ./code/:/pcw -t localhost/suse/qac/pcw-devel:latest "python3 manage.py cleanup"
2024-07-16 08:05:52,414 ocw.lib.cleanup INFO     [ccoe] Run cleanup for GCE
2024-07-16 08:05:52,415 ocw.lib.gce  INFO     [ccoe] Call cleanup_all
2024-07-16 08:05:52,415 ocw.lib.gce  DEBUG    [ccoe] Images cleanup
2024-07-16 08:05:52,853 ocw.lib.gce  DEBUG    [ccoe] 12 images found
2024-07-16 08:05:52,892 ocw.lib.gce  INFO     [ccoe] Deletion of image sl-micro-6-0-aarch64-1-0-0-gce-build2-20 skipped due to dry run mode
2024-07-16 08:05:52,893 ocw.lib.gce  INFO     [ccoe] Deletion of image sl-micro-6-0-byos-aarch64-1-0-0-gce-build2-19 skipped due to dry run mode
2024-07-16 08:05:52,893 ocw.lib.gce  INFO     [ccoe] Deletion of image sl-micro-6-0-byos-aarch64-1-0-0-gce-build2-20 skipped due to dry run mode
2024-07-16 08:05:52,893 ocw.lib.gce  INFO     [ccoe] Deletion of image sl-micro-6-0-byos-x8664-1-0-0-gce-build2-19 skipped due to dry run mode
2024-07-16 08:05:52,893 ocw.lib.gce  INFO     [ccoe] Deletion of image sl-micro-6-0-byos-x8664-1-0-0-gce-build2-20 skipped due to dry run mode
2024-07-16 08:05:52,893 ocw.lib.gce  INFO     [ccoe] Deletion of image sl-micro-6-0-x8664-1-0-0-gce-build2-20 skipped due to dry run mode
2024-07-16 08:05:52,893 ocw.lib.gce  INFO     [ccoe] Deletion of image sles12-sp5-gce-x8664-1-0-11-byos-build4-102 skipped due to dry run mode
2024-07-16 08:05:52,893 ocw.lib.gce  INFO     [ccoe] Deletion of image sles12-sp5-gce-x8664-1-0-14-sap-byos-build4-115 skipped due to dry run mode
2024-07-16 08:05:52,893 ocw.lib.gce  INFO     [ccoe] Deletion of image sles12-sp5-gce-x8664-1-0-14-sap-byos-build4-116 skipped due to dry run mode
2024-07-16 08:05:52,893 ocw.lib.gce  INFO     [ccoe] Deletion of image sles15-sp6-aarch64-1-0-0-gce-build1-27 skipped due to dry run mode
2024-07-16 08:05:52,893 ocw.lib.gce  DEBUG    [ccoe] Ignoring sles15-sp6-byos-aarch64-1-0-0-gce-build1-27 due to 'pcw_ignore' label set to '1'
2024-07-16 08:05:52,893 ocw.lib.gce  INFO     [ccoe] Deletion of image sles15-sp6-x8664-1-0-0-gce-build1-27 skipped due to dry run mode
```