### PR TITLE
Remove unused cleanup flow

### DIFF
--- a/ocw/lib/cleanup.py
+++ b/ocw/lib/cleanup.py
@@ -4,8 +4,7 @@ from webui.PCWConfig import PCWConfig
 from ocw.lib.azure import Azure
 from ocw.lib.ec2 import EC2
 from ocw.lib.gce import GCE
-from ocw.lib.eks import EKS
-from ocw.lib.emailnotify import send_mail, send_cluster_notification
+from ocw.lib.emailnotify import send_mail
 from ocw.enums import ProviderChoice
 
 logger = logging.getLogger(__name__)
@@ -28,16 +27,3 @@ def cleanup_run():
         except Exception as ex:
             logger.exception("[%s] Cleanup failed!", namespace)
             send_mail(f'{type(ex).__name__} on Cleanup in [{namespace}]', traceback.format_exc())
-
-
-def list_clusters():
-    for namespace in PCWConfig.get_namespaces_for('clusters'):
-        try:
-            clusters = EKS(namespace).all_clusters()
-            quantity = sum(len(clusters[c1]) for c1 in clusters)
-            logger.info("%d cluster(s) found", quantity)
-            if quantity > 0:
-                send_cluster_notification(namespace, clusters)
-        except Exception as ex:
-            logger.exception("[%s] List clusters failed!", namespace)
-            send_mail(f'{type(ex).__name__} on List clusters in [{namespace}]', traceback.format_exc())

--- a/ocw/lib/emailnotify.py
+++ b/ocw/lib/emailnotify.py
@@ -29,17 +29,6 @@ def draw_instance_table(objects):
     return table.draw()
 
 
-def send_cluster_notification(namespace, clusters):
-    if len(clusters) and PCWConfig.has('notify'):
-        clusters_str = ''
-        for region in clusters:
-            clusters_list = ' '.join([str(cluster) for cluster in clusters[region]])
-            clusters_str = f'{clusters_str}\n{region} : {clusters_list}'
-        logger.debug("Full clusters list - %s", clusters_str)
-        send_mail(f"[{namespace}] EC2 clusters found", clusters_str,
-                  receiver_email=PCWConfig.get_feature_property('notify', 'to', namespace))
-
-
 def send_mail(subject, message, receiver_email=None):
     if PCWConfig.has('notify'):
         smtp_server = PCWConfig.get_feature_property('notify', 'smtp')

--- a/webui/PCWConfig.py
+++ b/webui/PCWConfig.py
@@ -64,7 +64,6 @@ class PCWConfig():
             'updaterun/default_ttl': {'default': 44400, 'return_type': int},
             'notify/to': {'default': None, 'return_type': str},
             'notify/age-hours': {'default': 12, 'return_type': int},
-            'cluster.notify/to': {'default': None, 'return_type': str},
             'notify/smtp': {'default': None, 'return_type': str},
             'notify/smtp-port': {'default': 25, 'return_type': int},
             'notify/from': {'default': 'pcw@publiccloud.qa.suse.de', 'return_type': str},


### PR DESCRIPTION
We not using listing of EKS clusters anymore for years
because we stop running tests which creating clusters.
So this logic is orphaned and can/should be dropped