### PR TITLE
Adds logic to check for pcw_ignore flag

### DIFF
--- a/ocw/lib/gce.py
+++ b/ocw/lib/gce.py
@@ -177,9 +177,14 @@ class GCE(Provider):
                 self.log_dbg(f"{len(disks)} disks found")
                 for disk in disks:
                     if self.is_outdated(parse(disk["creationTimestamp"]).astimezone(timezone.utc)):
-                        self._delete_resource(
-                            self.compute_client().disks, disk["name"], project=self.project, zone=zone, disk=disk["name"]
-                        )
+                        labels = disk.get('labels', [])
+                        pcw_ignore_tag = 'pcw_ignore' in labels
+                        if pcw_ignore_tag:
+                            self.log_dbg(f"Ignoring {disk['name']} due to 'pcw_ignore' label set to '1'")
+                        else:
+                            self._delete_resource(
+                                self.compute_client().disks, disk["name"], project=self.project, zone=zone, disk=disk["name"]
+                            )
 
     def cleanup_images(self) -> None:
         self.log_dbg("Images cleanup")


### PR DESCRIPTION
This PR adds logic that allows us to prevent PCW from deleting disks in Google Cloud if the flag `pcw_ignore` is configured.


Related ticket: https://progress.opensuse.org/issues/174220 

Test run logs:

```
2025-01-29 17:26:16,560 ocw.lib.gce  DEBUG    [namespace] Searching for disks in europe-west1-b
2025-01-29 17:26:16,725 ocw.lib.gce  DEBUG    [namespace] 1 disks found
2025-01-29 17:26:16,789 ocw.lib.gce  DEBUG    [namespace] Ignoring testing-pcw-ignore due to 'pcw_ignore' label set to '1'

```