### PR TITLE
Adds check for default objects

### DIFF
--- a/ocw/lib/gce.py
+++ b/ocw/lib/gce.py
@@ -56,6 +56,9 @@ class GCE(Provider):
             self.compute_client().routes: "route",
             self.compute_client().subnetworks: "subnetwork",
         }.get(api_call, "resource")
+        if "default" in resource_name and "firewall" not in resource_type:
+            self.log_info(f"Skipped deletion of default {resource_type} {resource_name}")
+            return
         if self.dry_run:
             self.log_info(f"Deletion of {resource_type} {resource_name} skipped due to dry run mode")
             return


### PR DESCRIPTION
After https://github.com/SUSE/pcw/pull/270, PCW also cleans up network objects (Firewall rules, Routes, VPCs and etc.). 

We do not want to delete the default routes of the networks - https://progress.opensuse.org/issues/174262.

This PR adds a general check if the object has `default` in the name.

Example run:

```
2025-02-04 09:23:32,296 ocw.lib.gce  DEBUG    [ccoe] Routes cleanup
2025-02-04 09:23:32,641 ocw.lib.gce  DEBUG    [ccoe] 3 routes found
2025-02-04 09:23:32,685 ocw.lib.gce  INFO     [ccoe] Skipped deletion of default route default-route-155840a10ef83e70
2025-02-04 09:23:32,685 ocw.lib.gce  INFO     [ccoe] Skipped deletion of default route default-route-63d1541d1fcd3a75
2025-02-04 09:23:32,685 ocw.lib.gce  INFO     [ccoe] Skipped deletion of default route default-route-9c0a0f17c748564a
```