### PR TITLE
Adds general label handling for GCP

### DIFF
--- a/ocw/lib/gce.py
+++ b/ocw/lib/gce.py
@@ -56,6 +56,16 @@ class GCE(Provider):
             self.compute_client().routes: "route",
             self.compute_client().subnetworks: "subnetwork",
         }.get(api_call, "resource")
+
+        # Get object details / metadata and check the labels
+        resource_details = api_call().get(**kwargs).execute()
+        labels = resource_details.get('labels', {})
+        if labels:
+            self.log_dbg(f"Resource {resource_type}/{resource_name} has these labels: {labels}")
+            if 'pcw_ignore' in labels and labels["pcw_ignore"] == "1":
+                self.log_info(f"Skipping deletion of {resource_type} {resource_name} due to 'pcw_ignore' label set to 1")
+                return
+
         if self.dry_run:
             self.log_info(f"Deletion of {resource_type} {resource_name} skipped due to dry run mode")
             return

--- a/ocw/lib/gce.py
+++ b/ocw/lib/gce.py
@@ -62,8 +62,8 @@ class GCE(Provider):
         labels = resource_details.get('labels', {})
         if labels:
             self.log_dbg(f"Resource {resource_type}/{resource_name} has these labels: {labels}")
-            if 'pcw_ignore' in labels and labels["pcw_ignore"] == "1":
-                self.log_info(f"Skipping deletion of {resource_type} {resource_name} due to 'pcw_ignore' label set to 1")
+            if 'pcw_ignore' in labels:
+                self.log_info(f"Skipping deletion of {resource_type} {resource_name} due to 'pcw_ignore' label set on resource")
                 return
 
         if self.dry_run:

--- a/ocw/lib/gce.py
+++ b/ocw/lib/gce.py
@@ -187,14 +187,9 @@ class GCE(Provider):
                 self.log_dbg(f"{len(disks)} disks found")
                 for disk in disks:
                     if self.is_outdated(parse(disk["creationTimestamp"]).astimezone(timezone.utc)):
-                        labels = disk.get('labels', [])
-                        pcw_ignore_tag = 'pcw_ignore' in labels
-                        if pcw_ignore_tag:
-                            self.log_dbg(f"Ignoring {disk['name']} due to 'pcw_ignore' label set to '1'")
-                        else:
-                            self._delete_resource(
-                                self.compute_client().disks, disk["name"], project=self.project, zone=zone, disk=disk["name"]
-                            )
+                        self._delete_resource(
+                            self.compute_client().disks, disk["name"], project=self.project, zone=zone, disk=disk["name"]
+                        )
 
     def cleanup_images(self) -> None:
         self.log_dbg("Images cleanup")
@@ -202,14 +197,9 @@ class GCE(Provider):
         self.log_dbg(f"{len(images)} images found")
         for image in images:
             if self.is_outdated(parse(image["creationTimestamp"]).astimezone(timezone.utc)):
-                labels = image.get('labels', [])
-                pcw_ignore_tag = 'pcw_ignore' in labels
-                if pcw_ignore_tag:
-                    self.log_dbg(f"Ignoring {image['name']} due to 'pcw_ignore' label set to '1'")
-                else:
-                    self._delete_resource(
-                        self.compute_client().images, image["name"], project=self.project, image=image["name"]
-                    )
+                self._delete_resource(
+                    self.compute_client().images, image["name"], project=self.project, image=image["name"]
+                )
 
     def cleanup_firewalls(self) -> None:
         self.log_dbg("Firewalls cleanup")

--- a/tests/test_gce.py
+++ b/tests/test_gce.py
@@ -110,10 +110,11 @@ def mocked_resource():
                     'warnings': [{'message': 'warning message'}]}),
         MockRequest({
             'items': [
-                {'name': 'pcw_ignore', 'creationTimestamp': older_than_max_age, 'timeCreated': older_than_max_age, 'network': 'mynetwork', 'labels': {'pcw_ignore': '1'}}
+                {'name': 'pcw_ignore', 'creationTimestamp': older_than_max_age, 'timeCreated': older_than_max_age,
+                 'network': 'mynetwork', 'labels': {'pcw_ignore': '1'}}
             ], 'id': "id"
         }),
-        MockRequest(),  # on images().delete()  
+        MockRequest(),  # on images().delete()
         None   # on images().list_next()
     ])
 
@@ -145,11 +146,11 @@ def test_list_regions(gce):
 def test_list_zones(gce):
     gce.compute_client.regions = MockResource({'zones': ['somethingthatIdonotknow/RabbitHole']})
     gce.compute_client.list_zones = {'zones': ['somethingthatIdonotknow/RabbitHole']}
-    
+
     mock_region_response = {
         'zones': ['somethingthatIdonotknow/RabbitHole']
     }
- 
+
     # Mock the regions().get() method to return the mock response
     with patch.object(gce.compute_client.regions(), 'get', return_value=MockRequest(mock_region_response)):
         assert gce.list_zones('Oxfordshire') == ['RabbitHole']
@@ -236,17 +237,6 @@ def test_cleanup_networks(gce, mocked_resource, dry_run):
 
 @mark.parametrize("dry_run", [True, False])
 def test_pcw_ignore_label(gce, mocked_resource, dry_run):
-    resource_with_pcw_ignore = MockResource([
-        MockRequest({
-            'items': [
-                {'name': 'keep', 'creationTimestamp': '01/01/2023, 12:00:00', 'timeCreated': '01/01/2023, 12:00:00', 'network': 'mynetwork', 'labels': {'pcw_ignore': '1'}},
-                {'name': 'delete1', 'creationTimestamp': '01/01/2023, 12:00:00', 'timeCreated': '01/01/2023, 12:00:00', 'network': 'mynetwork'}
-            ], 'id': "id"
-        }),
-        MockRequest(),  # on images().delete()
-        None   # on images().list_next()
-    ])
-    
     gce.dry_run = dry_run
     _test_cleanup(gce, "images", gce.cleanup_images, mocked_resource)
 


### PR DESCRIPTION
### Summary
This PR adds general label handling for Google Cloud objects. 

There is an added check in `_delete_resource` so it affects all objects that have labels. Because of this I have removed the logic from `disks` and `images` as it's no longer needed.

### Progress
* https://progress.opensuse.org/issues/176238

### Run logs

```bash
2025-02-06 08:17:24,689 ocw.lib.gce  DEBUG    [ccoe] 2 disks found
2025-02-06 08:17:24,846 ocw.lib.gce  DEBUG    [ccoe] Resource disk/gke-qe-c-testing-default-pool-20255a71-00de has these labels: {<REDACTED>, 'pcw_ignore': '1'}
2025-02-06 08:17:24,846 ocw.lib.gce  INFO     [ccoe] Skipping deletion of disk gke-qe-c-testing-default-pool-20255a71-00de due to 'pcw_ignore' label set to 1
2025-02-06 08:17:24,986 ocw.lib.gce  DEBUG    [ccoe] Resource disk/gke-qe-c-testing-default-pool-20255a71-r2k9 has these labels: {<REDACTED>, 'pcw_ignore': '1'}
2025-02-06 08:17:24,986 ocw.lib.gce  INFO     [ccoe] Skipping deletion of disk gke-qe-c-testing-default-pool-20255a71-r2k9 due to 'pcw_ignore' label set to 1

```