### PR TITLE
Update Google dependencies

### DIFF
--- a/containers/Dockerfile_k8s
+++ b/containers/Dockerfile_k8s
@@ -1,9 +1,9 @@
 FROM registry.suse.com/bci/python:3.11
 
-RUN zypper -n in gcc tar gzip kubernetes1.28-client aws-cli && zypper clean && rm -rf /var/cache
+RUN zypper -n in gcc tar gzip kubernetes1.33-client aws-cli && zypper clean && rm -rf /var/cache
 
 # Google cli installation
-RUN curl -sf https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-415.0.0-linux-x86_64.tar.gz | tar -zxf - -C /opt \
+RUN curl -sf https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-427.0.0-linux-x86_64.tar.gz | tar -zxf - -C /opt \
 && /opt/google-cloud-sdk/bin/gcloud components install gke-gcloud-auth-plugin
 
 # Install python dependences
@@ -15,7 +15,7 @@ COPY ocw /pcw/ocw/
 COPY webui/PCWConfig.py /pcw/webui/PCWConfig.py
 COPY cleanup_k8s.py LICENSE README.md setup.cfg /pcw/
 
-ENV PATH ${PATH}:/opt/google-cloud-sdk/bin/
+ENV PATH=${PATH}:/opt/google-cloud-sdk/bin/
 
 WORKDIR /pcw
 

--- a/containers/Dockerfile_k8s_dev
+++ b/containers/Dockerfile_k8s_dev
@@ -1,16 +1,16 @@
 FROM registry.suse.com/bci/python:3.11
 
-RUN zypper -n in gcc tar gzip kubernetes1.28-client aws-cli && zypper clean && rm -rf /var/cache
+RUN zypper -n in gcc tar gzip kubernetes1.33-client aws-cli && zypper clean && rm -rf /var/cache
 
 # Google cli installation
-RUN curl -sf https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-415.0.0-linux-x86_64.tar.gz | tar -zxf - -C /opt \
+RUN curl -sf https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-427.0.0-linux-x86_64.tar.gz | tar -zxf - -C /opt \
 && /opt/google-cloud-sdk/bin/gcloud components install gke-gcloud-auth-plugin
 
 # Install python dependences
 COPY requirements_k8s.txt /pcw/
 RUN pip install --no-cache-dir wheel && pip install --no-cache-dir -r /pcw/requirements_k8s.txt
 
-ENV PATH ${PATH}:/opt/google-cloud-sdk/bin/
+ENV PATH=${PATH}:/opt/google-cloud-sdk/bin/
 
 WORKDIR /pcw
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ django~=5.1.6
 django-bootstrap5==24.3
 django-filter==25.1
 django-tables2==2.7.5
-google-api-python-client==2.162.0
+google-api-python-client==2.174.0
 httplib2==0.22.0
 influxdb-client==1.48.0
 msrest==0.7.1

--- a/requirements_k8s.txt
+++ b/requirements_k8s.txt
@@ -2,5 +2,5 @@ azure-cli==2.69.0
 azure-identity==1.20.0
 azure-mgmt-resource==23.1.1
 boto3==1.37.2
-google_api_python_client==2.162.0
+google_api_python_client==2.174.0
 kubernetes


### PR DESCRIPTION
- Update kubernetes to latest 1.33 version
- Update google-api-python-client
- Use `ENV var=value` idiom in Dockerfile to avoid:
`LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 18)`

Related ticket: https://progress.opensuse.org/issues/168550